### PR TITLE
Define basic interfaces and data structures

### DIFF
--- a/examples/end_to_end.rs
+++ b/examples/end_to_end.rs
@@ -1,0 +1,58 @@
+use measureme::{MmapSerializationSink, Profiler, ProfilingData, StringId, TimestampKind};
+use std::path::Path;
+use std::sync::Arc;
+
+const PROFILE_FILENAME_STEM: &str = "testprofile";
+
+// Generate some profiling data. This is the part that would run in rustc.
+fn generate_profiling_data() {
+    let profiler = Arc::new(Profiler::<MmapSerializationSink>::new(Path::new(
+        PROFILE_FILENAME_STEM,
+    )));
+
+    let event_kind_query_provider = profiler.alloc_string("Query");
+    let event_kind_generic = profiler.alloc_string("Generic");
+
+    let event_id_some_query = StringId::reserved(42);
+    let event_id_some_generic_activity = profiler.alloc_string("SomeGenericActivity");
+
+    let event_ids = &[
+        (event_kind_generic, event_id_some_generic_activity),
+        (event_kind_query_provider, event_id_some_query),
+    ];
+
+    let mut started_events = Vec::new();
+
+    for i in 0..10_000 {
+        // Allocate some invocation stacks
+        for _ in 0..4 {
+            let thread_id = (i % 3) as u64;
+            let (event_kind, event_id) = event_ids[i % event_ids.len()];
+
+            profiler.record_event(event_kind, event_id, thread_id, TimestampKind::Start);
+
+            started_events.push((event_kind, event_id, thread_id));
+        }
+
+        while let Some((event_kind, event_id, thread_id)) = started_events.pop() {
+            profiler.record_event(event_kind, event_id, thread_id, TimestampKind::End);
+        }
+    }
+
+    // An example of allocating the string contents of an event id that has
+    // already been used
+    profiler.alloc_string_with_reserved_id(event_id_some_query, "SomeQuery");
+}
+
+// Process some profiling data. This is the part that would run in a
+// post processing tool.
+fn process_profiling_data() {
+    let profiling_data = ProfilingData::new(Path::new(PROFILE_FILENAME_STEM));
+
+    profiling_data.iter_events(|_event| {});
+}
+
+fn main() {
+    generate_profiling_data();
+    process_profiling_data();
+}

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,0 +1,12 @@
+use crate::raw_event::TimestampKind;
+use std::borrow::Cow;
+use std::time::Instant;
+
+#[derive(Clone, Eq, PartialEq, Hash, Debug)]
+pub struct Event<'a> {
+    pub event_kind: Cow<'a, str>,
+    pub label: Cow<'a, str>,
+    pub additional_data: &'a [Cow<'a, str>],
+    pub timestamp: Instant,
+    pub timestamp_kind: TimestampKind,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,16 @@
+mod event;
+mod mmap_serialization_sink;
+mod profiler;
+mod profiling_data;
+mod raw_event;
 mod serialization;
 mod stringtable;
 
+pub use crate::event::Event;
+pub use crate::mmap_serialization_sink::MmapSerializationSink;
+pub use crate::profiler::Profiler;
+pub use crate::profiling_data::ProfilingData;
+pub use crate::raw_event::{RawEvent, TimestampKind};
 pub use crate::serialization::{Addr, SerializationSink};
 pub use crate::stringtable::{
     SerializableString, StringId, StringRef, StringTable, StringTableBuilder,

--- a/src/mmap_serialization_sink.rs
+++ b/src/mmap_serialization_sink.rs
@@ -1,0 +1,18 @@
+use crate::serialization::{Addr, SerializationSink};
+use std::path::Path;
+
+pub struct MmapSerializationSink {}
+
+impl SerializationSink for MmapSerializationSink {
+    fn from_path(_path: &Path) -> Self {
+        unimplemented!()
+    }
+
+    #[inline]
+    fn write_atomic<W>(&self, _num_bytes: usize, _write: W) -> Addr
+    where
+        W: FnOnce(&mut [u8]),
+    {
+        unimplemented!()
+    }
+}

--- a/src/profiler.rs
+++ b/src/profiler.rs
@@ -1,0 +1,76 @@
+use crate::raw_event::{RawEvent, Timestamp, TimestampKind};
+use crate::serialization::SerializationSink;
+use crate::stringtable::{SerializableString, StringId, StringTableBuilder};
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Instant;
+
+pub struct Profiler<S: SerializationSink> {
+    event_sink: Arc<S>,
+    string_table: StringTableBuilder<S>,
+    start_time: Instant,
+}
+
+impl<S: SerializationSink> Profiler<S> {
+    pub fn new(path_stem: &Path) -> Profiler<S> {
+        let event_sink = Arc::new(S::from_path(&path_stem.with_extension("events")));
+        let string_table = StringTableBuilder::new(
+            Arc::new(S::from_path(&path_stem.with_extension("string_data"))),
+            Arc::new(S::from_path(&path_stem.with_extension("string_index"))),
+        );
+
+        Profiler {
+            event_sink,
+            string_table,
+            start_time: Instant::now(),
+        }
+    }
+
+    #[inline(always)]
+    pub fn alloc_string_with_reserved_id<STR: SerializableString + ?Sized>(
+        &self,
+        id: StringId,
+        s: &STR,
+    ) -> StringId {
+        self.string_table.alloc_with_reserved_id(id, s)
+    }
+
+    #[inline(always)]
+    pub fn alloc_string<STR: SerializableString + ?Sized>(&self, s: &STR) -> StringId {
+        self.string_table.alloc(s)
+    }
+
+    pub fn record_event(
+        &self,
+        event_kind: StringId,
+        event_id: StringId,
+        thread_id: u64,
+        timestamp_kind: TimestampKind,
+    ) {
+        let duration_since_start = self.start_time.elapsed();
+        let nanos_since_start = duration_since_start.as_secs() * 1_000_000_000
+            + duration_since_start.subsec_nanos() as u64;
+        let timestamp = Timestamp::new(nanos_since_start, timestamp_kind);
+
+        self.event_sink
+            .write_atomic(std::mem::size_of::<RawEvent>(), |bytes| {
+                debug_assert_eq!(bytes.len(), std::mem::size_of::<RawEvent>());
+
+                let raw_event = RawEvent {
+                    event_kind,
+                    id: event_id,
+                    thread_id,
+                    timestamp,
+                };
+
+                let raw_event_bytes: &[u8] = unsafe {
+                    std::slice::from_raw_parts(
+                        &raw_event as *const _ as *const u8,
+                        std::mem::size_of::<RawEvent>(),
+                    )
+                };
+
+                bytes.copy_from_slice(raw_event_bytes);
+            });
+    }
+}

--- a/src/profiling_data.rs
+++ b/src/profiling_data.rs
@@ -1,0 +1,17 @@
+use crate::event::Event;
+use std::path::Path;
+
+pub struct ProfilingData {}
+
+impl ProfilingData {
+    pub fn new(_path_stem: &Path) -> ProfilingData {
+        unimplemented!()
+    }
+
+    pub fn iter_events<'a, F>(&'a self, mut _f: F)
+    where
+        F: FnMut(&Event<'a>),
+    {
+        unimplemented!()
+    }
+}

--- a/src/raw_event.rs
+++ b/src/raw_event.rs
@@ -1,0 +1,43 @@
+use crate::stringtable::StringId;
+
+#[derive(Clone, Eq, PartialEq, Hash, Debug)]
+pub enum TimestampKind {
+    Start = 0,
+    End = 1,
+    Instant = 2,
+}
+
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+#[repr(C)]
+pub struct Timestamp(u64);
+
+impl Timestamp {
+    #[inline]
+    pub fn new(nanos: u64, kind: TimestampKind) -> Timestamp {
+        Timestamp((nanos << 2) | kind as u64)
+    }
+
+    #[inline]
+    pub fn nanos(self) -> u64 {
+        self.0 >> 2
+    }
+
+    #[inline]
+    pub fn kind(self) -> TimestampKind {
+        match self.0 & 0b11 {
+            0 => TimestampKind::Start,
+            1 => TimestampKind::End,
+            2 => TimestampKind::Instant,
+            _ => unreachable!(),
+        }
+    }
+}
+
+#[derive(Eq, PartialEq, Debug)]
+#[repr(C)]
+pub struct RawEvent {
+    pub event_kind: StringId,
+    pub id: StringId,
+    pub thread_id: u64,
+    pub timestamp: Timestamp,
+}

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 #[derive(Clone, Copy, Eq, PartialEq, Debug)]
 pub struct Addr(pub u32);
 
@@ -8,6 +10,8 @@ impl Addr {
 }
 
 pub trait SerializationSink {
+    fn from_path(path: &Path) -> Self;
+
     fn write_atomic<W>(&self, num_bytes: usize, write: W) -> Addr
     where
         W: FnOnce(&mut [u8]);
@@ -35,6 +39,10 @@ pub mod test {
     }
 
     impl SerializationSink for TestSink {
+        fn from_path(path: &Path) -> Self {
+            unimplemented!()
+        }
+
         fn write_atomic<W>(&self, num_bytes: usize, write: W) -> Addr
         where
             W: FnOnce(&mut [u8]),


### PR DESCRIPTION
This PR defines the basic data types and interfaces of the library.
`tests/end_to_end.rs` contains an example of how I roughly imagine the public API of the crate to look like.

~~This is not meant to be merged yet (it doesn't even compile).~~

cc @wesleywiser 