### PR TITLE
Change dependencies to match existing rustc deps

### DIFF
--- a/measureme/Cargo.toml
+++ b/measureme/Cargo.toml
@@ -10,6 +10,6 @@ license = "MIT OR Apache-2.0"
 travis-ci = { repository = "rust-lang/measureme" }
 
 [dependencies]
-byteorder = "1.3"
+byteorder = "1.2.7"
 rustc-hash = "1.0.1"
-memmap = "0.7.0"
+memmap = "0.6.0"


### PR DESCRIPTION
While working on https://github.com/rust-lang/rust/pull/59515, I noticed that some shared dependencies between rustc and measureme were getting updated when adding the measureme dependency. This commit changes our dependency versions to match those of rustc.