### PR TITLE
Support wasm and wasi

### DIFF
--- a/measureme/Cargo.toml
+++ b/measureme/Cargo.toml
@@ -15,4 +15,6 @@ travis-ci = { repository = "rust-lang/measureme" }
 [dependencies]
 byteorder = "1.2.7"
 rustc-hash = "1.0.1"
+
+[target.'cfg(not(target_arch="wasm32"))'.dependencies]
 memmap = "0.6.0"

--- a/measureme/src/lib.rs
+++ b/measureme/src/lib.rs
@@ -1,6 +1,8 @@
 mod event;
 mod file_header;
+#[cfg(any(not(target_arch="wasm32"), target_os="wasi"))]
 mod file_serialization_sink;
+#[cfg(not(target_arch="wasm32"))]
 mod mmap_serialization_sink;
 mod profiler;
 mod profiling_data;
@@ -12,7 +14,9 @@ pub mod rustc;
 pub mod testing_common;
 
 pub use crate::event::Event;
+#[cfg(any(not(target_arch="wasm32"), target_os="wasi"))]
 pub use crate::file_serialization_sink::FileSerializationSink;
+#[cfg(not(target_arch="wasm32"))]
 pub use crate::mmap_serialization_sink::MmapSerializationSink;
 pub use crate::profiler::{Profiler, ProfilerFiles};
 pub use crate::profiling_data::{ProfilingData, MatchingEvent};


### PR DESCRIPTION
This is part of an experiment to port rustc to wasi. (cc https://github.com/rust-lang/miri/issues/722)

Webassembly doesn't support any mmap like mechanism.