### PR TITLE
[mmview] Add a thread-id filter argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 ### Added
 - `measureme`: Added support for compiling the library under wasm/wasi ([GH-43])
+- `mmview`: Added the `-t` flag to limit output to results on the specified thread id ([GH-49])
 
 ## [0.3.0] - 2019-05-14
 ### Added
@@ -23,3 +24,4 @@
 [GH-35]: https://github.com/rust-lang/measureme/pull/35
 [GH-41]: https://github.com/rust-lang/measureme/pull/41
 [GH-43]: https://github.com/rust-lang/measureme/pull/43
+[GH-49]: https://github.com/rust-lang/measureme/pull/49

--- a/mmview/src/main.rs
+++ b/mmview/src/main.rs
@@ -7,6 +7,10 @@ use structopt::StructOpt;
 #[derive(StructOpt, Debug)]
 struct Opt {
     file_prefix: PathBuf,
+
+    /// Filter to events which occured on the specified thread id
+    #[structopt(short = "t", long = "thread-id")]
+    thread_id: Option<u64>,
 }
 
 fn main() -> Result<(), Box<dyn Error>> {
@@ -15,6 +19,12 @@ fn main() -> Result<(), Box<dyn Error>> {
     let data = ProfilingData::new(&opt.file_prefix)?;
 
     for event in data.iter() {
+        if let Some(thread_id) = opt.thread_id {
+            if event.thread_id != thread_id {
+                continue;
+            }
+        }
+
         println!("{:?}", event);
     }
 

--- a/summarize/src/analysis.rs
+++ b/summarize/src/analysis.rs
@@ -147,8 +147,8 @@ pub fn perform_analysis(data: ProfilingData) -> Results {
                 let thread_stack = threads.get_mut(&event.thread_id).unwrap();
                 let start_event = thread_stack.pop().unwrap();
 
-                assert_eq!(start_event.event_kind, event.event_kind);
                 assert_eq!(start_event.label, event.label);
+                assert_eq!(start_event.event_kind, event.event_kind);
                 assert_eq!(start_event.timestamp_kind, TimestampKind::Start);
 
                 //track the time for this event


### PR DESCRIPTION
I also made it easier to troubleshoot invalid event files which can cause assertion failures in `summarize`. 