### PR TITLE
add option to crox to filter out short events

### DIFF
--- a/crox/src/main.rs
+++ b/crox/src/main.rs
@@ -46,6 +46,9 @@ struct Opt {
     /// collapse threads without overlapping events
     #[structopt(long = "collapse-threads")]
     collapse_threads: bool,
+    /// filter out events with shorter duration (in microseconds)
+    #[structopt(long = "minimum-duration")]
+    minimum_duration: u128,
 }
 
 // generate mapping from thread_id to collapsed thread_id or an empty map
@@ -130,7 +133,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             // only handle startStop events for now
             if let MatchingEvent::StartStop(start, stop) = event {
                 let duration = stop.timestamp.duration_since(start.timestamp).unwrap();
-
+                if duration.as_micros() < opt.minimum_duration {
+                    continue;
+                }
                 return Some(Event {
                     name: start.label.clone().into_owned(),
                     category: start.event_kind.clone().into_owned(),


### PR DESCRIPTION
some files is to large to show in the browser
filter_duration_ms filter out all events that is shorter than specified limit