### PR TITLE
Replace (start, stop) event pairs with interval events.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 ### Added
 - `flamegraph`: new tool that uses the `inferno` crate to generate flamegraph svg files ([GH-73])
 
+### Changed
+- `measureme`: Events are recorded in a more compact format ([GH-76])
+- `stack_collapse`: Removed the `--interval` commandline option ([GH-76])
+
 ## [0.4.0] - 2019-10-24
 ### Added
 - `measureme`: Added RAII-based API for recording events ([GH-70])
@@ -42,3 +46,4 @@
 [GH-60]: https://github.com/rust-lang/measureme/pull/60
 [GH-70]: https://github.com/rust-lang/measureme/pull/70
 [GH-73]: https://github.com/rust-lang/measureme/pull/73
+[GH-76]: https://github.com/rust-lang/measureme/pull/76

--- a/flamegraph/src/main.rs
+++ b/flamegraph/src/main.rs
@@ -14,10 +14,6 @@ use inferno::flamegraph::{from_lines, Options as FlamegraphOptions};
 #[derive(StructOpt, Debug)]
 struct Opt {
     file_prefix: PathBuf,
-
-    /// The sampling interval in milliseconds
-    #[structopt(short = "i", long = "interval", default_value = "1")]
-    interval: u64,
 }
 
 fn main() -> Result<(), Box<dyn Error>> {
@@ -25,7 +21,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let profiling_data = ProfilingData::new(&opt.file_prefix)?;
 
-    let recorded_stacks = collapse_stacks(profiling_data.iter(), opt.interval)
+    let recorded_stacks = collapse_stacks(&profiling_data)
         .iter()
         .map(|(unique_stack, count)| format!("{} {}", unique_stack, count))
         .collect::<Vec<_>>();

--- a/measureme/src/event.rs
+++ b/measureme/src/event.rs
@@ -1,13 +1,86 @@
-use crate::raw_event::TimestampKind;
+use crate::raw_event::RawEvent;
 use std::borrow::Cow;
-use std::time::SystemTime;
+use std::time::{Duration, SystemTime};
 
 #[derive(Clone, Eq, PartialEq, Hash, Debug)]
 pub struct Event<'a> {
     pub event_kind: Cow<'a, str>,
     pub label: Cow<'a, str>,
     pub additional_data: &'a [Cow<'a, str>],
-    pub timestamp: SystemTime,
-    pub timestamp_kind: TimestampKind,
+    pub timestamp: Timestamp,
     pub thread_id: u64,
+}
+
+impl<'a> Event<'a> {
+    /// Returns true if the time interval of `self` completely contains the
+    /// time interval of `other`.
+    pub fn contains(&self, other: &Event<'_>) -> bool {
+        match self.timestamp {
+            Timestamp::Interval {
+                start: self_start,
+                end: self_end,
+            } => match other.timestamp {
+                Timestamp::Interval {
+                    start: other_start,
+                    end: other_end,
+                } => self_start <= other_start && other_end <= self_end,
+                Timestamp::Instant(other_t) => self_start <= other_t && other_t <= self_end,
+            },
+            Timestamp::Instant(_) => false,
+        }
+    }
+
+    pub fn duration(&self) -> Option<Duration> {
+        match self.timestamp {
+            Timestamp::Interval { start, end } => end.duration_since(start).ok(),
+            Timestamp::Instant(_) => None,
+        }
+    }
+}
+
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+pub enum Timestamp {
+    Interval { start: SystemTime, end: SystemTime },
+    Instant(SystemTime),
+}
+
+impl Timestamp {
+    pub fn from_raw_event(raw_event: &RawEvent, start_time: SystemTime) -> Timestamp {
+        if raw_event.end_ns == std::u64::MAX {
+            let t = start_time + Duration::from_nanos(raw_event.start_ns);
+            Timestamp::Instant(t)
+        } else {
+            let start = start_time + Duration::from_nanos(raw_event.start_ns);
+            let end = start_time + Duration::from_nanos(raw_event.end_ns);
+            Timestamp::Interval { start, end }
+        }
+    }
+
+    pub fn contains(&self, t: SystemTime) -> bool {
+        match *self {
+            Timestamp::Interval { start, end } => t >= start && t < end,
+            Timestamp::Instant(_) => false,
+        }
+    }
+
+    pub fn is_instant(&self) -> bool {
+        match *self {
+            Timestamp::Interval { .. } => false,
+            Timestamp::Instant(_) => true,
+        }
+    }
+
+    pub fn start(&self) -> SystemTime {
+        match *self {
+            Timestamp::Interval { start, .. } => start,
+            Timestamp::Instant(t) => t,
+        }
+    }
+
+    pub fn end(&self) -> SystemTime {
+        match *self {
+            Timestamp::Interval { end, .. } => end,
+            Timestamp::Instant(t) => t,
+        }
+    }
 }

--- a/measureme/src/file_header.rs
+++ b/measureme/src/file_header.rs
@@ -6,7 +6,7 @@ use crate::serialization::SerializationSink;
 use byteorder::{ByteOrder, LittleEndian};
 use std::error::Error;
 
-pub const CURRENT_FILE_FORMAT_VERSION: u32 = 0;
+pub const CURRENT_FILE_FORMAT_VERSION: u32 = 1;
 pub const FILE_MAGIC_EVENT_STREAM: &[u8; 4] = b"MMES";
 pub const FILE_MAGIC_STRINGTABLE_DATA: &[u8; 4] = b"MMSD";
 pub const FILE_MAGIC_STRINGTABLE_INDEX: &[u8; 4] = b"MMSI";

--- a/measureme/src/lib.rs
+++ b/measureme/src/lib.rs
@@ -50,7 +50,6 @@
 //! [`ProfilingData::iter()`]: struct.ProfilingData.html#method.iter
 //! [`ProfilingData::iter_matching_events()`]: struct.ProfilingData.html#method.iter_matching_events
 //! [`StringId`]: struct.StringId.html
-//! [`TimestampKind`]: enum.TimestampKind.html
 
 #![deny(warnings)]
 
@@ -69,14 +68,14 @@ mod stringtable;
 pub mod rustc;
 pub mod testing_common;
 
-pub use crate::event::Event;
+pub use crate::event::{Event, Timestamp};
 #[cfg(any(not(target_arch = "wasm32"), target_os = "wasi"))]
 pub use crate::file_serialization_sink::FileSerializationSink;
 #[cfg(not(target_arch = "wasm32"))]
 pub use crate::mmap_serialization_sink::MmapSerializationSink;
 pub use crate::profiler::{Profiler, ProfilerFiles, TimingGuard};
-pub use crate::profiling_data::{MatchingEvent, ProfilingData, ProfilingDataBuilder};
-pub use crate::raw_event::{RawEvent, Timestamp, TimestampKind};
+pub use crate::profiling_data::{ProfilingData, ProfilingDataBuilder};
+pub use crate::raw_event::RawEvent;
 pub use crate::serialization::{Addr, ByteVecSink, SerializationSink};
 pub use crate::stringtable::{
     SerializableString, StringId, StringRef, StringTable, StringTableBuilder,

--- a/measureme/src/serialization.rs
+++ b/measureme/src/serialization.rs
@@ -19,7 +19,6 @@ pub trait SerializationSink: Sized {
         W: FnOnce(&mut [u8]);
 }
 
-
 /// A `SerializationSink` that writes to an internal `Vec<u8>` and can be
 /// converted into this raw `Vec<u8>`. This implementation is only meant to be
 /// used for testing and is not very efficient.

--- a/measureme/src/testing_common.rs
+++ b/measureme/src/testing_common.rs
@@ -1,4 +1,4 @@
-use crate::{Event, Profiler, ProfilingData, SerializationSink, StringId, TimestampKind};
+use crate::{Event, Profiler, ProfilingData, SerializationSink, StringId, Timestamp};
 use rustc_hash::FxHashMap;
 use std::borrow::Cow;
 use std::default::Default;
@@ -38,40 +38,18 @@ fn generate_profiling_data<S: SerializationSink>(filestem: &Path) -> Vec<Event<'
     event_ids_as_str.insert(event_ids[1].1, "SomeQuery");
 
     let mut expected_events = Vec::new();
-    let mut started_events = Vec::new();
 
     for i in 0..10_000 {
         // Allocate some invocation stacks
-        for _ in 0..4 {
-            let thread_id = (i % 3) as u64;
 
-            let (event_kind, event_id) = event_ids[i % event_ids.len()];
-
-            profiler.record_event(event_kind, event_id, thread_id, TimestampKind::Start);
-            started_events.push((event_kind, event_id, thread_id));
-
-            expected_events.push(Event {
-                event_kind: Cow::from(event_ids_as_str[&event_kind]),
-                label: Cow::from(event_ids_as_str[&event_id]),
-                additional_data: &[],
-                timestamp: SystemTime::UNIX_EPOCH, // We can't test this anyway,
-                timestamp_kind: TimestampKind::Start,
-                thread_id,
-            });
-        }
-
-        while let Some((event_kind, event_id, thread_id)) = started_events.pop() {
-            profiler.record_event(event_kind, event_id, thread_id, TimestampKind::End);
-
-            expected_events.push(Event {
-                event_kind: Cow::from(event_ids_as_str[&event_kind]),
-                label: Cow::from(event_ids_as_str[&event_id]),
-                additional_data: &[],
-                timestamp: SystemTime::UNIX_EPOCH, // We can't test this anyway,
-                timestamp_kind: TimestampKind::End,
-                thread_id,
-            });
-        }
+        pseudo_invocation(
+            &profiler,
+            i,
+            4,
+            event_ids,
+            &event_ids_as_str,
+            &mut expected_events,
+        );
     }
 
     // An example of allocating the string contents of an event id that has
@@ -86,24 +64,86 @@ fn generate_profiling_data<S: SerializationSink>(filestem: &Path) -> Vec<Event<'
 fn process_profiling_data(filestem: &Path, expected_events: &[Event<'static>]) {
     let profiling_data = ProfilingData::new(filestem).unwrap();
 
+    check_profiling_data(
+        &mut profiling_data.iter(),
+        &mut expected_events.iter().cloned(),
+        expected_events.len(),
+    );
+    check_profiling_data(
+        &mut profiling_data.iter().rev(),
+        &mut expected_events.iter().rev().cloned(),
+        expected_events.len(),
+    );
+}
+
+fn check_profiling_data(
+    actual_events: &mut dyn Iterator<Item = Event<'_>>,
+    expected_events: &mut dyn Iterator<Item = Event<'_>>,
+    num_expected_events: usize,
+) {
     let mut count = 0;
 
-    for (actual_event, expected_event) in profiling_data.iter().zip(expected_events.iter()) {
-        eprintln!("{:?}", actual_event);
+    assert_eq!(
+        (num_expected_events, Some(num_expected_events)),
+        actual_events.size_hint()
+    );
 
+    for (actual_event, expected_event) in actual_events.zip(expected_events) {
         assert_eq!(actual_event.event_kind, expected_event.event_kind);
         assert_eq!(actual_event.label, expected_event.label);
         assert_eq!(actual_event.additional_data, expected_event.additional_data);
-        assert_eq!(actual_event.timestamp_kind, expected_event.timestamp_kind);
+        assert_eq!(
+            actual_event.timestamp.is_instant(),
+            expected_event.timestamp.is_instant()
+        );
 
         count += 1;
     }
-
-    assert_eq!(count, expected_events.len());
+    assert_eq!(count, num_expected_events);
 }
 
 pub fn run_end_to_end_serialization_test<S: SerializationSink>(file_name_stem: &str) {
     let filestem = mk_filestem(file_name_stem);
     let expected_events = generate_profiling_data::<S>(&filestem);
     process_profiling_data(&filestem, &expected_events);
+}
+
+fn pseudo_invocation<S: SerializationSink>(
+    profiler: &Profiler<S>,
+    random: usize,
+    recursions_left: usize,
+    event_ids: &[(StringId, StringId)],
+    event_ids_as_str: &FxHashMap<StringId, &'static str>,
+    expected_events: &mut Vec<Event<'static>>,
+) {
+    if recursions_left == 0 {
+        return;
+    }
+
+    let thread_id = (random % 3) as u64;
+
+    let (event_kind, event_id) = event_ids[random % event_ids.len()];
+
+    let _prof_guard = profiler.start_recording_interval_event(event_kind, event_id, thread_id);
+
+    pseudo_invocation(
+        profiler,
+        random,
+        recursions_left - 1,
+        event_ids,
+        event_ids_as_str,
+        expected_events,
+    );
+
+    expected_events.push(Event {
+        event_kind: Cow::from(event_ids_as_str[&event_kind]),
+        label: Cow::from(event_ids_as_str[&event_id]),
+        additional_data: &[],
+        // We can't test this anyway:
+        timestamp: Timestamp::Interval {
+            start: SystemTime::UNIX_EPOCH,
+            end: SystemTime::UNIX_EPOCH,
+        },
+        thread_id,
+    });
 }

--- a/stack_collapse/src/main.rs
+++ b/stack_collapse/src/main.rs
@@ -12,10 +12,6 @@ use tools_lib::stack_collapse::collapse_stacks;
 #[derive(StructOpt, Debug)]
 struct Opt {
     file_prefix: PathBuf,
-
-    /// The sampling interval in milliseconds
-    #[structopt(short = "i", long = "interval", default_value = "1")]
-    interval: u64,
 }
 
 fn main() -> Result<(), Box<dyn Error>> {
@@ -23,7 +19,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let profiling_data = ProfilingData::new(&opt.file_prefix)?;
 
-    let recorded_stacks = collapse_stacks(profiling_data.iter(), opt.interval);
+    let recorded_stacks = collapse_stacks(&profiling_data);
 
     let mut file = BufWriter::new(File::create("out.stacks_folded")?);
 


### PR DESCRIPTION
This reduces the number of events that need to be recorded.

~~Currently the PR updates all tools except `stack_collapse` which seems to be in flux at the moment. It also does not yet use the raw event format (i.e. the number of bits used for timestamps and thread-ids is unnecessarily high).~~

I intend to optimize the raw format of events and the string table in subsequent PR. This one already contains enough changes.

@wesleywiser Let me know if prefer the PR to be split up into more commits.