### PR TITLE
Replace HashMap with `rustc_hash::FxHashMap` in Tools

### DIFF
--- a/crox/Cargo.toml
+++ b/crox/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [dependencies]
 measureme = { "path" = "../measureme" }
+rustc-hash = "1.0.1"
 serde = { version = "1.0", features = [ "derive" ] }
 serde_json = "1.0"
 structopt = "0.2"

--- a/crox/src/main.rs
+++ b/crox/src/main.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use rustc_hash::FxHashMap;
 use std::fs;
 use std::io::BufWriter;
 use std::path::PathBuf;
@@ -38,7 +38,7 @@ struct Event {
     process_id: u32,
     #[serde(rename = "tid")]
     thread_id: u64,
-    args: Option<BTreeMap<String, String>>,
+    args: Option<FxHashMap<String, String>>,
 }
 
 #[derive(StructOpt, Debug)]
@@ -56,12 +56,12 @@ struct Opt {
 fn generate_thread_to_collapsed_thread_mapping(
     opt: &Opt,
     data: &ProfilingData,
-) -> BTreeMap<u64, u64> {
-    let mut thread_to_collapsed_thread: BTreeMap<u64, u64> = BTreeMap::new();
+) -> FxHashMap<u64, u64> {
+    let mut thread_to_collapsed_thread: FxHashMap<u64, u64> = FxHashMap::default();
 
     if opt.collapse_threads {
         // collect start and end times for all threads
-        let mut thread_start_and_end: BTreeMap<u64, (SystemTime, SystemTime)> = BTreeMap::new();
+        let mut thread_start_and_end: FxHashMap<u64, (SystemTime, SystemTime)> = FxHashMap::default();
         for event in data.iter() {
             thread_start_and_end
                 .entry(event.thread_id)

--- a/summarize/Cargo.toml
+++ b/summarize/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 measureme = { path = "../measureme" }
 prettytable-rs = "0.8"
+rustc-hash = "1.0.1"
 serde = { version = "1.0", features = [ "derive" ] }
 serde_json = "1.0"
 structopt = "0.2"

--- a/summarize/src/analysis.rs
+++ b/summarize/src/analysis.rs
@@ -1,9 +1,9 @@
 use crate::query_data::{QueryData, Results};
 use measureme::rustc::*;
 use measureme::{Event, ProfilingData, Timestamp};
+use rustc_hash::FxHashMap;
 use std::borrow::Cow;
-use std::collections::HashMap;
-use std::time::{Duration, SystemTime};
+use std::time::SystemTime;
 
 /// Collects accumulated summary data for the given ProfilingData.
 ///
@@ -116,8 +116,8 @@ pub fn perform_analysis(data: ProfilingData) -> Results {
         end: SystemTime,
     }
 
-    let mut query_data = HashMap::<String, QueryData>::new();
-    let mut threads = HashMap::<_, PerThreadState>::new();
+    let mut query_data = FxHashMap::<String, QueryData>::default();
+    let mut threads = FxHashMap::<_, PerThreadState>::default();
 
     let mut record_event_data = |label: &Cow<'_, str>, f: &dyn Fn(&mut QueryData)| {
         if let Some(data) = query_data.get_mut(&label[..]) {
@@ -219,6 +219,7 @@ pub fn perform_analysis(data: ProfilingData) -> Results {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::Duration;
     use measureme::ProfilingDataBuilder;
 
     #[test]

--- a/summarize/src/diff.rs
+++ b/summarize/src/diff.rs
@@ -1,7 +1,7 @@
 use crate::query_data::{QueryData, QueryDataDiff, Results};
 use crate::signed_duration::SignedDuration;
+use rustc_hash::{FxHashMap, FxHashSet};
 use serde::{Deserialize, Serialize};
-use std::collections::{HashMap, HashSet};
 use std::time::Duration;
 
 #[derive(Serialize, Deserialize)]
@@ -10,8 +10,8 @@ pub struct DiffResults {
     pub total_time: SignedDuration,
 }
 
-fn build_query_lookup(query_data: &[QueryData]) -> HashMap<&str, usize> {
-    let mut lookup = HashMap::with_capacity(query_data.len());
+fn build_query_lookup(query_data: &[QueryData]) -> FxHashMap<&str, usize> {
+    let mut lookup = FxHashMap::with_capacity_and_hasher(query_data.len(), Default::default());
     for i in 0..query_data.len() {
         lookup.insert(&query_data[i].label[..], i);
     }
@@ -28,7 +28,7 @@ pub fn calculate_diff(base: Results, change: Results) -> DiffResults {
     let base_data = build_query_lookup(&base.query_data);
     let change_data = build_query_lookup(&change.query_data);
 
-    let mut all_labels = HashSet::with_capacity(base.query_data.len() + change.query_data.len());
+    let mut all_labels = FxHashSet::with_capacity_and_hasher(base.query_data.len() + change.query_data.len(), Default::default());
     for query_data in base.query_data.iter().chain(&change.query_data) {
         all_labels.insert(&query_data.label[..]);
     }

--- a/tools_lib/Cargo.toml
+++ b/tools_lib/Cargo.toml
@@ -7,3 +7,4 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 measureme = { path = "../measureme" }
+rustc-hash = "1.0.1"

--- a/tools_lib/src/stack_collapse.rs
+++ b/tools_lib/src/stack_collapse.rs
@@ -1,5 +1,5 @@
+use rustc_hash::FxHashMap;
 use std::cmp;
-use std::collections::HashMap;
 use std::time::SystemTime;
 
 use measureme::{Event, ProfilingData};
@@ -17,9 +17,9 @@ struct PerThreadState<'a> {
 /// Uses a variation of the algorithm in `summarize`.
 // Original implementation provided by @andjo403 in
 // https://github.com/michaelwoerister/measureme/pull/1
-pub fn collapse_stacks<'a>(profiling_data: &ProfilingData) -> HashMap<String, u64> {
-    let mut counters = HashMap::new();
-    let mut threads = HashMap::<_, PerThreadState<'_>>::new();
+pub fn collapse_stacks<'a>(profiling_data: &ProfilingData) -> FxHashMap<String, u64> {
+    let mut counters = FxHashMap::default();
+    let mut threads = FxHashMap::<_, PerThreadState<'_>>::default();
 
     for current_event in profiling_data
         .iter()
@@ -95,7 +95,7 @@ pub fn collapse_stacks<'a>(profiling_data: &ProfilingData) -> HashMap<String, u6
 #[cfg(test)]
 mod test {
     use measureme::ProfilingDataBuilder;
-    use std::collections::HashMap;
+    use rustc_hash::FxHashMap;
 
     #[test]
     fn basic_test() {
@@ -124,7 +124,7 @@ mod test {
 
         let recorded_stacks = super::collapse_stacks(&profiling_data);
 
-        let mut expected_stacks = HashMap::<String, u64>::new();
+        let mut expected_stacks = FxHashMap::<String, u64>::default();
         expected_stacks.insert("rustc;e2;e1;e3".into(), 2);
         expected_stacks.insert("rustc;e2;e1".into(), 2);
         expected_stacks.insert("rustc;e2".into(), 2);
@@ -161,7 +161,7 @@ mod test {
 
         let recorded_stacks = super::collapse_stacks(&profiling_data);
 
-        let mut expected_stacks = HashMap::<String, u64>::new();
+        let mut expected_stacks = FxHashMap::<String, u64>::default();
         expected_stacks.insert("rustc;e2;e3".into(), 1);
         expected_stacks.insert("rustc;e2".into(), 2);
         expected_stacks.insert("rustc;e1".into(), 3);


### PR DESCRIPTION
### Summary

Tries to fix Issue #77 .

1. Replaces HashMap with `rustc_hash::FxHashMap`.
2. Replaces HashSet with `rustc_hash::FxHashSet`.

Based on @michaelwoerister 's help,  I fixed to replace `HashMap::with_capacity` with `FxHashMap::with_capacity_and_hasher`. Thanks.