### PR TITLE
use meta data in crox events to be able to merge multiple logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 ### Added
 - `flamegraph`: new tool that uses the `inferno` crate to generate flamegraph svg files ([GH-73])
+- `crox`: Added the `--dir` parameter to merge all events files in dir in to one trace file ([GH-84])
+- `crox`: Added possibility to add multiple `file_prefix` parameters to merge all them to one trace file ([GH-84])
 
 ### Changed
 - `measureme`: Events are recorded in a more compact format ([GH-76])
@@ -47,3 +49,4 @@
 [GH-70]: https://github.com/rust-lang/measureme/pull/70
 [GH-73]: https://github.com/rust-lang/measureme/pull/73
 [GH-76]: https://github.com/rust-lang/measureme/pull/76
+[GH-84]: https://github.com/rust-lang/measureme/pull/84

--- a/analyzeme/Cargo.toml
+++ b/analyzeme/Cargo.toml
@@ -8,3 +8,5 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 measureme = { path = "../measureme" }
 rustc-hash = "1.0.1"
+serde = { version = "1.0", features = [ "derive" ] }
+serde_json = "1.0"

--- a/analyzeme/src/profiling_data.rs
+++ b/analyzeme/src/profiling_data.rs
@@ -26,7 +26,7 @@ where
 }
 
 #[derive(Deserialize)]
-pub struct MetaData {
+pub struct Metadata {
     #[serde(deserialize_with = "system_time_from_nanos")]
     pub start_time: SystemTime,
     pub process_id: u32,
@@ -36,7 +36,7 @@ pub struct MetaData {
 pub struct ProfilingData {
     event_data: Vec<u8>,
     string_table: StringTable,
-    pub meta_data: MetaData,
+    pub metadata: Metadata,
 }
 
 impl ProfilingData {
@@ -59,13 +59,13 @@ impl ProfilingData {
 
         let string_table = StringTable::new(string_data, index_data)?;
 
-        let meta_data = string_table.get_metadata().to_string();
-        let meta_data: MetaData = serde_json::from_str(&meta_data)?;
+        let metadata = string_table.get_metadata().to_string();
+        let metadata: Metadata = serde_json::from_str(&metadata)?;
 
         Ok(ProfilingData {
             string_table,
             event_data,
-            meta_data,
+            metadata,
         })
     }
 
@@ -112,7 +112,7 @@ impl<'a> ProfilerEventIterator<'a> {
 
         let string_table = &self.data.string_table;
 
-        let timestamp = Timestamp::from_raw_event(&raw_event, self.data.meta_data.start_time);
+        let timestamp = Timestamp::from_raw_event(&raw_event, self.data.metadata.start_time);
 
         Event {
             event_kind: string_table.get(raw_event.event_kind).to_string(),
@@ -263,7 +263,7 @@ impl ProfilingDataBuilder {
             CURRENT_FILE_FORMAT_VERSION
         );
         let string_table = StringTable::new(data_bytes, index_bytes).unwrap();
-        let meta_data = MetaData {
+        let metadata = Metadata {
             start_time: UNIX_EPOCH,
             process_id: 0,
             cmd: "test cmd".to_string(),
@@ -272,7 +272,7 @@ impl ProfilingDataBuilder {
         ProfilingData {
             event_data,
             string_table,
-            meta_data,
+            metadata,
         }
     }
 

--- a/crox/src/main.rs
+++ b/crox/src/main.rs
@@ -146,7 +146,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 event_type: EventType::Complete,
                 timestamp: event.timestamp.start().duration_since(UNIX_EPOCH).unwrap(),
                 duration,
-                process_id: data.meta_data.process_id,
+                process_id: data.metadata.process_id,
                 thread_id: *thread_to_collapsed_thread
                     .get(&event.thread_id)
                     .unwrap_or(&event.thread_id),
@@ -156,12 +156,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
         // add crate name for the process_id
         let index_of_crate_name = data
-            .meta_data
+            .metadata
             .cmd
             .find(" --crate-name ")
             .map(|index| index + 14);
         if let Some(index) = index_of_crate_name {
-            let (_, last) = data.meta_data.cmd.split_at(index);
+            let (_, last) = data.metadata.cmd.split_at(index);
             let (crate_name, _) = last.split_at(last.find(" ").unwrap_or(last.len()));
 
             let process_name = json!({
@@ -170,7 +170,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 "ts" : 0,
                 "tid" : 0,
                 "cat" : "",
-                "pid" : data.meta_data.process_id,
+                "pid" : data.metadata.process_id,
                 "args": {
                     "name" : crate_name
                 }
@@ -184,9 +184,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             "ts" : 0,
             "tid" : 0,
             "cat" : "",
-            "pid" : data.meta_data.process_id,
+            "pid" : data.metadata.process_id,
             "args": {
-                "sort_index" : data.meta_data.start_time.duration_since(UNIX_EPOCH).unwrap().as_micros() as u64
+                "sort_index" : data.metadata.start_time.duration_since(UNIX_EPOCH).unwrap().as_micros() as u64
             }
         });
         seq.serialize_element(&process_name)?;

--- a/measureme/src/stringtable.rs
+++ b/measureme/src/stringtable.rs
@@ -295,6 +295,10 @@ impl StringTable {
     pub fn get<'a>(&'a self, id: StringId) -> StringRef<'a> {
         StringRef { id, table: self }
     }
+    pub fn get_metadata<'a>(&'a self) -> StringRef<'a> {
+        let id = StringId(METADATA_STRING_ID);
+        self.get(id)
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
add parameter `--dir` that merges all events in the directory to one chrome_profiler.json file.
makes it possible to give multiple file_prefixes and will merge all of them to one chrome_profiler.json file.
also use the crate name from the cmd metadata to show what process_id  is from what crate build.