### PR TITLE
Make sure all crates compile on nightly and beta.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: rust
 rust:
   - stable
+  - beta
+  - nightly

--- a/measureme/src/serialization.rs
+++ b/measureme/src/serialization.rs
@@ -60,7 +60,7 @@ impl SerializationSink for ByteVecSink {
 }
 
 impl std::fmt::Debug for ByteVecSink {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "ByteVecSink")
     }
 }


### PR DESCRIPTION
Using the crate as part of `rustc` requires that it build on nightly. Let's make sure we catch cases early where it doesn't. This PR contains a fix for such a problem.

r? @wesleywiser 