### PR TITLE
Only use 48 bits for encoding timestamps and 32 bits for encoding thread IDs in RawEvent in order to make it smaller.

### DIFF
--- a/analyzeme/src/event.rs
+++ b/analyzeme/src/event.rs
@@ -8,7 +8,7 @@ pub struct Event<'a> {
     pub label: Cow<'a, str>,
     pub additional_data: &'a [Cow<'a, str>],
     pub timestamp: Timestamp,
-    pub thread_id: u64,
+    pub thread_id: u32,
 }
 
 impl<'a> Event<'a> {
@@ -46,12 +46,12 @@ pub enum Timestamp {
 
 impl Timestamp {
     pub fn from_raw_event(raw_event: &RawEvent, start_time: SystemTime) -> Timestamp {
-        if raw_event.end_ns == std::u64::MAX {
-            let t = start_time + Duration::from_nanos(raw_event.start_ns);
+        if raw_event.is_instant() {
+            let t = start_time + Duration::from_nanos(raw_event.start_nanos());
             Timestamp::Instant(t)
         } else {
-            let start = start_time + Duration::from_nanos(raw_event.start_ns);
-            let end = start_time + Duration::from_nanos(raw_event.end_ns);
+            let start = start_time + Duration::from_nanos(raw_event.start_nanos());
+            let end = start_time + Duration::from_nanos(raw_event.end_nanos());
             Timestamp::Interval { start, end }
         }
     }

--- a/analyzeme/src/profiling_data.rs
+++ b/analyzeme/src/profiling_data.rs
@@ -204,7 +204,7 @@ impl ProfilingDataBuilder {
         &mut self,
         event_kind: &str,
         event_id: &str,
-        thread_id: u64,
+        thread_id: u32,
         start_nanos: u64,
         end_nanos: u64,
         inner: F,
@@ -230,7 +230,7 @@ impl ProfilingDataBuilder {
         &mut self,
         event_kind: &str,
         event_id: &str,
-        thread_id: u64,
+        thread_id: u32,
         timestamp_nanos: u64,
     ) -> &mut Self {
         let event_kind = self.string_table.alloc(event_kind);
@@ -307,7 +307,7 @@ mod tests {
     fn interval(
         event_kind: &'static str,
         label: &'static str,
-        thread_id: u64,
+        thread_id: u32,
         start_nanos: u64,
         end_nanos: u64,
     ) -> Event<'static> {
@@ -326,7 +326,7 @@ mod tests {
     fn instant(
         event_kind: &'static str,
         label: &'static str,
-        thread_id: u64,
+        thread_id: u32,
         timestamp_nanos: u64,
     ) -> Event<'static> {
         Event {

--- a/analyzeme/src/testing_common.rs
+++ b/analyzeme/src/testing_common.rs
@@ -121,7 +121,7 @@ fn pseudo_invocation<S: SerializationSink>(
         return;
     }
 
-    let thread_id = (random % 3) as u64;
+    let thread_id = (random % 3) as u32;
 
     let (event_kind, event_id) = event_ids[random % event_ids.len()];
 

--- a/crox/src/main.rs
+++ b/crox/src/main.rs
@@ -38,7 +38,7 @@ struct Event {
     #[serde(rename = "pid")]
     process_id: u32,
     #[serde(rename = "tid")]
-    thread_id: u64,
+    thread_id: u32,
     args: Option<FxHashMap<String, String>>,
 }
 
@@ -61,12 +61,12 @@ struct Opt {
 fn generate_thread_to_collapsed_thread_mapping(
     opt: &Opt,
     data: &ProfilingData,
-) -> FxHashMap<u64, u64> {
-    let mut thread_to_collapsed_thread: FxHashMap<u64, u64> = FxHashMap::default();
+) -> FxHashMap<u32, u32> {
+    let mut thread_to_collapsed_thread: FxHashMap<u32, u32> = FxHashMap::default();
 
     if opt.collapse_threads {
         // collect start and end times for all threads
-        let mut thread_start_and_end: FxHashMap<u64, (SystemTime, SystemTime)> =
+        let mut thread_start_and_end: FxHashMap<u32, (SystemTime, SystemTime)> =
             FxHashMap::default();
         for event in data.iter() {
             thread_start_and_end

--- a/measureme/src/file_header.rs
+++ b/measureme/src/file_header.rs
@@ -6,7 +6,7 @@ use crate::serialization::SerializationSink;
 use byteorder::{ByteOrder, LittleEndian};
 use std::error::Error;
 
-pub const CURRENT_FILE_FORMAT_VERSION: u32 = 1;
+pub const CURRENT_FILE_FORMAT_VERSION: u32 = 2;
 pub const FILE_MAGIC_EVENT_STREAM: &[u8; 4] = b"MMES";
 pub const FILE_MAGIC_STRINGTABLE_DATA: &[u8; 4] = b"MMSD";
 pub const FILE_MAGIC_STRINGTABLE_INDEX: &[u8; 4] = b"MMSI";

--- a/measureme/src/lib.rs
+++ b/measureme/src/lib.rs
@@ -55,7 +55,7 @@ pub use crate::file_serialization_sink::FileSerializationSink;
 #[cfg(not(target_arch = "wasm32"))]
 pub use crate::mmap_serialization_sink::MmapSerializationSink;
 pub use crate::profiler::{Profiler, ProfilerFiles, TimingGuard};
-pub use crate::raw_event::RawEvent;
+pub use crate::raw_event::{RawEvent, MAX_INSTANT_TIMESTAMP, MAX_INTERVAL_TIMESTAMP};
 pub use crate::serialization::{Addr, ByteVecSink, SerializationSink};
 pub use crate::stringtable::{
     SerializableString, StringId, StringRef, StringTable, StringTableBuilder,

--- a/measureme/src/profiler.rs
+++ b/measureme/src/profiler.rs
@@ -110,16 +110,7 @@ impl<S: SerializationSink> Profiler<S> {
     fn record_raw_event(&self, raw_event: &RawEvent) {
         self.event_sink
             .write_atomic(std::mem::size_of::<RawEvent>(), |bytes| {
-                debug_assert_eq!(bytes.len(), std::mem::size_of::<RawEvent>());
-
-                let raw_event_bytes: &[u8] = unsafe {
-                    std::slice::from_raw_parts(
-                        raw_event as *const _ as *const u8,
-                        std::mem::size_of::<RawEvent>(),
-                    )
-                };
-
-                bytes.copy_from_slice(raw_event_bytes);
+                raw_event.serialize(bytes);
             });
     }
 

--- a/measureme/src/profiler.rs
+++ b/measureme/src/profiler.rs
@@ -83,7 +83,7 @@ impl<S: SerializationSink> Profiler<S> {
 
     /// Records an event with the given parameters. The event time is computed
     /// automatically.
-    pub fn record_instant_event(&self, event_kind: StringId, event_id: StringId, thread_id: u64) {
+    pub fn record_instant_event(&self, event_kind: StringId, event_id: StringId, thread_id: u32) {
         let raw_event =
             RawEvent::new_instant(event_kind, event_id, thread_id, self.nanos_since_start());
 
@@ -96,7 +96,7 @@ impl<S: SerializationSink> Profiler<S> {
         &'a self,
         event_kind: StringId,
         event_id: StringId,
-        thread_id: u64,
+        thread_id: u32,
     ) -> TimingGuard<'a, S> {
         TimingGuard {
             profiler: self,
@@ -136,7 +136,7 @@ pub struct TimingGuard<'a, S: SerializationSink> {
     profiler: &'a Profiler<S>,
     event_id: StringId,
     event_kind: StringId,
-    thread_id: u64,
+    thread_id: u32,
     start_ns: u64,
 }
 

--- a/measureme/src/stringtable.rs
+++ b/measureme/src/stringtable.rs
@@ -51,6 +51,11 @@ impl StringId {
     pub fn reserved(id: u32) -> StringId {
         StringId(id)
     }
+
+    #[inline]
+    pub fn as_u32(self) -> u32 {
+        self.0
+    }
 }
 
 // Tags for the binary encoding of strings

--- a/mmview/src/main.rs
+++ b/mmview/src/main.rs
@@ -10,7 +10,7 @@ struct Opt {
 
     /// Filter to events which occured on the specified thread id
     #[structopt(short = "t", long = "thread-id")]
-    thread_id: Option<u64>,
+    thread_id: Option<u32>,
 }
 
 fn main() -> Result<(), Box<dyn Error>> {


### PR DESCRIPTION
This restricts us to timestamps of at most ~78 hours after process start which seems acceptable. 
The PR reduces the size of `RawEvent` (and thus the size of our event stream files) by 25%.