### PR TITLE
Optimize FileSerializationSink by using parking_lot::Mutex and avoiding heap allocations in write_atomic.

### DIFF
--- a/analyzeme/benches/serialization_bench.rs
+++ b/analyzeme/benches/serialization_bench.rs
@@ -8,8 +8,8 @@ use measureme::{FileSerializationSink, MmapSerializationSink};
 #[bench]
 fn bench_file_serialization_sink(bencher: &mut test::Bencher) {
     bencher.iter(|| {
-        testing_common::run_end_to_end_serialization_test::<FileSerializationSink>(
-            "file_serialization_sink_test",
+        testing_common::run_serialization_bench::<FileSerializationSink>(
+            "file_serialization_sink_test", 500_000, 1
         );
     });
 }
@@ -17,8 +17,26 @@ fn bench_file_serialization_sink(bencher: &mut test::Bencher) {
 #[bench]
 fn bench_mmap_serialization_sink(bencher: &mut test::Bencher) {
     bencher.iter(|| {
-        testing_common::run_end_to_end_serialization_test::<MmapSerializationSink>(
-            "mmap_serialization_sink_test",
+        testing_common::run_serialization_bench::<MmapSerializationSink>(
+            "mmap_serialization_sink_test", 500_000, 1
+        );
+    });
+}
+
+#[bench]
+fn bench_file_serialization_sink_8_threads(bencher: &mut test::Bencher) {
+    bencher.iter(|| {
+        testing_common::run_serialization_bench::<FileSerializationSink>(
+            "file_serialization_sink_test", 50_000, 8
+        );
+    });
+}
+
+#[bench]
+fn bench_mmap_serialization_sink_8_threads(bencher: &mut test::Bencher) {
+    bencher.iter(|| {
+        testing_common::run_serialization_bench::<MmapSerializationSink>(
+            "mmap_serialization_sink_test", 50_000, 8
         );
     });
 }

--- a/analyzeme/tests/serialization.rs
+++ b/analyzeme/tests/serialization.rs
@@ -2,11 +2,21 @@ use analyzeme::testing_common::run_end_to_end_serialization_test;
 use measureme::{FileSerializationSink, MmapSerializationSink};
 
 #[test]
-fn test_file_serialization_sink() {
-    run_end_to_end_serialization_test::<FileSerializationSink>("file_serialization_sink_test");
+fn test_file_serialization_sink_1_thread() {
+    run_end_to_end_serialization_test::<FileSerializationSink>("file_serialization_sink_test_1_thread", 1);
 }
 
 #[test]
-fn test_mmap_serialization_sink() {
-    run_end_to_end_serialization_test::<MmapSerializationSink>("mmap_serialization_sink_test");
+fn test_file_serialization_sink_8_threads() {
+    run_end_to_end_serialization_test::<FileSerializationSink>("file_serialization_sink_test_8_threads", 8);
+}
+
+#[test]
+fn test_mmap_serialization_sink_1_thread() {
+    run_end_to_end_serialization_test::<MmapSerializationSink>("mmap_serialization_sink_test_1_thread", 1);
+}
+
+#[test]
+fn test_mmap_serialization_sink_8_threads() {
+    run_end_to_end_serialization_test::<MmapSerializationSink>("mmap_serialization_sink_test_8_threads", 8);
 }

--- a/measureme/Cargo.toml
+++ b/measureme/Cargo.toml
@@ -15,6 +15,7 @@ travis-ci = { repository = "rust-lang/measureme" }
 [dependencies]
 byteorder = "1.2.7"
 rustc-hash = "1.0.1"
+parking_lot = "0.9"
 
 [target.'cfg(not(target_arch="wasm32"))'.dependencies]
 memmap = "0.6.0"

--- a/measureme/src/file_serialization_sink.rs
+++ b/measureme/src/file_serialization_sink.rs
@@ -1,12 +1,19 @@
 use crate::serialization::{Addr, SerializationSink};
 use std::error::Error;
 use std::fs;
-use std::io::{BufWriter, Write};
+use std::io::{Write};
 use std::path::Path;
-use std::sync::Mutex;
+use parking_lot::Mutex;
 
 pub struct FileSerializationSink {
-    data: Mutex<(BufWriter<fs::File>, u32)>,
+    data: Mutex<Inner>,
+}
+
+struct Inner {
+    file: fs::File,
+    buffer: Vec<u8>,
+    buf_pos: usize,
+    addr: u32,
 }
 
 impl SerializationSink for FileSerializationSink {
@@ -16,7 +23,12 @@ impl SerializationSink for FileSerializationSink {
         let file = fs::File::create(path)?;
 
         Ok(FileSerializationSink {
-            data: Mutex::new((BufWriter::new(file), 0)),
+            data: Mutex::new(Inner {
+                file,
+                buffer: vec![0; 1024*512],
+                buf_pos: 0,
+                addr: 0
+            }),
         })
     }
 
@@ -25,17 +37,45 @@ impl SerializationSink for FileSerializationSink {
     where
         W: FnOnce(&mut [u8]),
     {
-        let mut buffer = vec![0; num_bytes];
-        write(buffer.as_mut_slice());
+        let mut data = self.data.lock();
+        let Inner {
+            ref mut file,
+            ref mut buffer,
+            ref mut buf_pos,
+            ref mut addr
+        } = *data;
 
-        let mut data = self.data.lock().expect("couldn't acquire lock");
-        let curr_addr = data.1;
-        let file = &mut data.0;
+        assert!(num_bytes <= buffer.len());
+        let mut buf_start = *buf_pos;
+        let mut buf_end = buf_start + num_bytes;
 
-        file.write_all(&buffer).expect("failed to write buffer");
+        if buf_end > buffer.len() {
+            file.write_all(&buffer[..buf_start]).expect("failed to write buffer");
+            buf_start = 0;
+            buf_end = num_bytes;
+        }
 
-        data.1 += num_bytes as u32;
+        write(&mut buffer[buf_start .. buf_end]);
+        *buf_pos = buf_end;
 
+        let curr_addr = *addr;
+        *addr += num_bytes as u32;
         Addr(curr_addr)
+    }
+}
+
+impl Drop for FileSerializationSink {
+    fn drop(&mut self) {
+        let mut data = self.data.lock();
+        let Inner {
+            ref mut file,
+            ref mut buffer,
+            ref mut buf_pos,
+            addr: _,
+        } = *data;
+
+        if *buf_pos > 0 {
+            file.write_all(&buffer[..*buf_pos]).expect("failed to write buffer");
+        }
     }
 }

--- a/measureme/src/serialization.rs
+++ b/measureme/src/serialization.rs
@@ -11,7 +11,7 @@ impl Addr {
     }
 }
 
-pub trait SerializationSink: Sized {
+pub trait SerializationSink: Sized + Send + Sync + 'static {
     fn from_path(path: &Path) -> Result<Self, Box<dyn Error>>;
 
     fn write_atomic<W>(&self, num_bytes: usize, write: W) -> Addr

--- a/measureme/src/serialization.rs
+++ b/measureme/src/serialization.rs
@@ -1,6 +1,6 @@
 use std::error::Error;
 use std::path::Path;
-use std::sync::Mutex;
+use parking_lot::Mutex;
 
 #[derive(Clone, Copy, Eq, PartialEq, Debug)]
 pub struct Addr(pub u32);
@@ -34,7 +34,7 @@ impl ByteVecSink {
     }
 
     pub fn into_bytes(self) -> Vec<u8> {
-        self.data.into_inner().unwrap()
+        self.data.into_inner()
     }
 }
 
@@ -47,7 +47,7 @@ impl SerializationSink for ByteVecSink {
     where
         W: FnOnce(&mut [u8]),
     {
-        let mut data = self.data.lock().unwrap();
+        let mut data = self.data.lock();
 
         let start = data.len();
 


### PR DESCRIPTION
This PR makes the `FileSerializationSink` exactly as fast as the `MmapSerializationSink` in the benchmarks we have. But I only tested on Linux and I also remember that the benchmarks were no good indication of performance when used in `rustc`.

It would be nice if we could get rid of the `MmapSerializationSink` because it keeps everything in memory until the end.

I wonder how much work it would be to have benchmarks that actually run `rustc`. It's a hassle to test this manually.