### PR TITLE
measureme: Update memmap to 0.7.0, and bump version to 0.4.1

### DIFF
--- a/measureme/Cargo.toml
+++ b/measureme/Cargo.toml
@@ -17,4 +17,4 @@ byteorder = "1.2.7"
 rustc-hash = "1.0.1"
 
 [target.'cfg(not(target_arch="wasm32"))'.dependencies]
-memmap = "0.6.0"
+memmap = "0.7.0"

--- a/measureme/Cargo.toml
+++ b/measureme/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "measureme"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Wesley Wiser <wwiser@gmail.com>", "Michael Woerister <michaelwoerister@posteo>"]
 edition = "2018"
 description = "Support crate for rustc's self-profiling feature"


### PR DESCRIPTION
memmap 0.7.0 has support for Redox, hence the need for this change. No compatibility issues required fixing, it still passes all tests.