### PR TITLE
Support query events stacked on incremental_load events in summarize.

### DIFF
--- a/summarize/src/query_data.rs
+++ b/summarize/src/query_data.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use std::ops::Sub;
 use std::time::Duration;
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct QueryData {
     pub label: String,
     pub self_time: Duration,


### PR DESCRIPTION
Fixes the issue found in https://github.com/rust-lang/rust/pull/66981. The should be correct but this could be cleaned up even more if the questions in https://github.com/rust-lang/measureme/issues/75 were properly answered. Would be good to do that before the next bigger release.

r? @wesleywiser or @andjo403 