### PR TITLE
Virtual instead of reserved string ids

### DIFF
--- a/analyzeme/src/testing_common.rs
+++ b/analyzeme/src/testing_common.rs
@@ -26,14 +26,14 @@ fn generate_profiling_data<S: SerializationSink>(
 ) -> Vec<Event<'static>> {
     let profiler = Arc::new(Profiler::<S>::new(Path::new(filestem)).unwrap());
 
-    let event_id_reserved = StringId::reserved(42);
+    let event_id_virtual = StringId::new_virtual(42);
 
     let event_ids = vec![
         (
             profiler.alloc_string("Generic"),
             profiler.alloc_string("SomeGenericActivity"),
         ),
-        (profiler.alloc_string("Query"), event_id_reserved),
+        (profiler.alloc_string("Query"), event_id_virtual),
     ];
 
     // This and event_ids have to match!
@@ -73,7 +73,10 @@ fn generate_profiling_data<S: SerializationSink>(
 
     // An example of allocating the string contents of an event id that has
     // already been used
-    profiler.alloc_string_with_reserved_id(event_id_reserved, "SomeQuery");
+    profiler.map_virtual_to_concrete_string(
+        event_id_virtual,
+        profiler.alloc_string("SomeQuery")
+    );
 
     expected_events
 }

--- a/measureme/src/file_header.rs
+++ b/measureme/src/file_header.rs
@@ -6,7 +6,7 @@ use crate::serialization::SerializationSink;
 use byteorder::{ByteOrder, LittleEndian};
 use std::error::Error;
 
-pub const CURRENT_FILE_FORMAT_VERSION: u32 = 3;
+pub const CURRENT_FILE_FORMAT_VERSION: u32 = 4;
 pub const FILE_MAGIC_EVENT_STREAM: &[u8; 4] = b"MMES";
 pub const FILE_MAGIC_STRINGTABLE_DATA: &[u8; 4] = b"MMSD";
 pub const FILE_MAGIC_STRINGTABLE_INDEX: &[u8; 4] = b"MMSI";

--- a/measureme/src/profiler.rs
+++ b/measureme/src/profiler.rs
@@ -68,12 +68,21 @@ impl<S: SerializationSink> Profiler<S> {
     }
 
     #[inline(always)]
-    pub fn alloc_string_with_reserved_id<STR: SerializableString + ?Sized>(
+    pub fn map_virtual_to_concrete_string(&self, virtual_id: StringId, concrete_id: StringId) {
+        self.string_table
+            .map_virtual_to_concrete_string(virtual_id, concrete_id);
+    }
+
+    #[inline(always)]
+    pub fn bulk_map_virtual_to_single_concrete_string<I>(
         &self,
-        id: StringId,
-        s: &STR,
-    ) -> StringId {
-        self.string_table.alloc_with_reserved_id(id, s)
+        virtual_ids: I,
+        concrete_id: StringId,
+    ) where
+        I: Iterator<Item = StringId> + ExactSizeIterator,
+    {
+        self.string_table
+            .bulk_map_virtual_to_single_concrete_string(virtual_ids, concrete_id);
     }
 
     #[inline(always)]
@@ -92,6 +101,7 @@ impl<S: SerializationSink> Profiler<S> {
 
     /// Creates a "start" event and returns a `TimingGuard` that will create
     /// the corresponding "end" event when it is dropped.
+    #[inline]
     pub fn start_recording_interval_event<'a>(
         &'a self,
         event_kind: StringId,


### PR DESCRIPTION
This PR removes some unnecessary overhead from the StringTable format. 

> With this commit only "virtual" StringIds get an entry in the index table and regular StringIds
store an actual address instead of index table key. That makes the index data a lot smaller
and removes the need to do a table lookup for regular StringIds.

This optimization becomes important when recording query keys because we allocate a lot more string data in that case.

~~This PR also contains the changes from https://github.com/rust-lang/measureme/pull/97. Feel free to review/merge all at once or separately.~~