### PR TITLE
Add API for overriding initial event_id before recording an event and bump version to 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.6.0] - 2019-12-11
+### Added
+- `measureme`: Added `SerializationSink::write_bytes_atomic` that optimizes handling of existing buffers ([GH-97])
+
+### Changed
+- `summarize`: Fixed a crash when incr_cache_load events would have child events ([GH-93])
+- `measureme`: Replaced notion of "reserved" StringIds with simpler "virtual" StringIds ([GH-98])
+
 ## [0.5.0] - 2019-12-02
 ### Added
 - `flamegraph`: new tool that uses the `inferno` crate to generate flamegraph svg files ([GH-73])
@@ -54,3 +62,6 @@
 [GH-84]: https://github.com/rust-lang/measureme/pull/84
 [GH-87]: https://github.com/rust-lang/measureme/pull/87
 [GH-90]: https://github.com/rust-lang/measureme/pull/90
+[GH-93]: https://github.com/rust-lang/measureme/pull/93
+[GH-97]: https://github.com/rust-lang/measureme/pull/97
+[GH-98]: https://github.com/rust-lang/measureme/pull/98

--- a/analyzeme/Cargo.toml
+++ b/analyzeme/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "analyzeme"
-version = "0.1.0"
+version = "0.6.0"
 authors = ["Wesley Wiser <wwiser@gmail.com>", "Michael Woerister <michaelwoerister@posteo>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/crox/Cargo.toml
+++ b/crox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crox"
-version = "0.1.0"
+version = "0.6.0"
 authors = ["Wesley Wiser <wwiser@gmail.com>"]
 edition = "2018"
 

--- a/flamegraph/Cargo.toml
+++ b/flamegraph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flamegraph"
-version = "0.1.0"
+version = "0.6.0"
 authors = ["Wesley Wiser <wwiser@gmail.com>", "Michael Woerister <michaelwoerister@posteo>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/measureme/Cargo.toml
+++ b/measureme/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "measureme"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Wesley Wiser <wwiser@gmail.com>", "Michael Woerister <michaelwoerister@posteo>"]
 edition = "2018"
 description = "Support crate for rustc's self-profiling feature"

--- a/measureme/src/profiler.rs
+++ b/measureme/src/profiler.rs
@@ -155,3 +155,15 @@ impl<'a, S: SerializationSink> Drop for TimingGuard<'a, S> {
         self.profiler.record_raw_event(&raw_event);
     }
 }
+
+impl<'a, S: SerializationSink> TimingGuard<'a, S> {
+
+    /// This method set a new `event_id` right before actually recording the
+    /// event.
+    #[inline]
+    pub fn finish_with_override_event_id(mut self, event_id: StringId) {
+        self.event_id = event_id;
+        // Let's be explicit about it: Dropping the guard will record the event.
+        drop(self)
+    }
+}

--- a/mmview/Cargo.toml
+++ b/mmview/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mmview"
-version = "0.1.0"
+version = "0.6.0"
 authors = ["Wesley Wiser <wwiser@gmail.com>", "Michael Woerister <michaelwoerister@posteo>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/stack_collapse/Cargo.toml
+++ b/stack_collapse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stack_collapse"
-version = "0.1.0"
+version = "0.6.0"
 authors = ["Wesley Wiser <wwiser@gmail.com>", "Michael Woerister <michaelwoerister@posteo>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/summarize/Cargo.toml
+++ b/summarize/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "summarize"
-version = "0.1.0"
+version = "0.6.0"
 authors = ["Wesley Wiser <wwiser@gmail.com>", "Michael Woerister <michaelwoerister@posteo>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
This PR adds a small piece of functionality that is needed for query key recording. In `rustc` we (will) use the `DepNodeIndex` as the virtual `StringId` that ends up being the `event_id`. However, the `DepNodeIndex` is often only generated after we already started recording the corresponding event. So we need a way of overwriting the `event_id` once we know what to actually set it to.

This PR also bumps the version to `0.6.0` for _all_ crates in the repo. As @Mark-Simulacrum pointed out, it makes sense to have one version number for the entire workspace (with the expectation that the tools and libraries of the same version number are always compatible with each other).

r? @wesleywiser 