### PR TITLE
Add support of having arguments on events.

### DIFF
--- a/analyzeme/src/event.rs
+++ b/analyzeme/src/event.rs
@@ -104,7 +104,7 @@ impl<'a> Parser<'a> {
 
         self.pos = end;
 
-        if self.full_text[start .. end].iter().any(u8::is_ascii_control) {
+        if self.full_text[start..end].iter().any(u8::is_ascii_control) {
             return self.err("Found ASCII control character in <text>");
         }
 
@@ -166,8 +166,7 @@ mod tests {
 
     #[test]
     fn parse_event_id_n_args() {
-        let (label, args) =
-            Event::parse_event_id(Cow::from("foo\x1earg1\x1earg2\x1earg3"));
+        let (label, args) = Event::parse_event_id(Cow::from("foo\x1earg1\x1earg2\x1earg3"));
 
         assert_eq!(label, "foo");
         assert_eq!(

--- a/analyzeme/src/event.rs
+++ b/analyzeme/src/event.rs
@@ -1,12 +1,16 @@
 use crate::timestamp::Timestamp;
+use memchr::memchr;
 use std::borrow::Cow;
 use std::time::Duration;
+
+const SEPARATOR: u8 = 0x1E;
+const ARG_TAG: u8 = 0x11;
 
 #[derive(Clone, Eq, PartialEq, Hash, Debug)]
 pub struct Event<'a> {
     pub event_kind: Cow<'a, str>,
     pub label: Cow<'a, str>,
-    pub additional_data: &'a [Cow<'a, str>],
+    pub additional_data: Vec<Cow<'a, str>>,
     pub timestamp: Timestamp,
     pub thread_id: u32,
 }
@@ -35,5 +39,145 @@ impl<'a> Event<'a> {
             Timestamp::Interval { start, end } => end.duration_since(start).ok(),
             Timestamp::Instant(_) => None,
         }
+    }
+
+    pub(crate) fn parse_event_id(event_id: Cow<'a, str>) -> (Cow<'a, str>, Vec<Cow<'a, str>>) {
+        let event_id = match event_id {
+            Cow::Owned(s) => Cow::Owned(s.into_bytes()),
+            Cow::Borrowed(s) => Cow::Borrowed(s.as_bytes()),
+        };
+
+        let mut parser = Parser::new(event_id);
+
+        let label = match parser.parse_label() {
+            Ok(label) => label,
+            Err(message) => {
+                eprintln!("{}", message);
+                return (Cow::from("<parse error>"), Vec::new());
+            }
+        };
+
+        let mut args = Vec::new();
+
+        while parser.pos != parser.full_text.len() {
+            match parser.parse_arg() {
+                Ok(arg) => args.push(arg),
+                Err(message) => {
+                    eprintln!("{}", message);
+                    break;
+                }
+            }
+        }
+
+        (label, args)
+    }
+}
+
+struct Parser<'a> {
+    full_text: Cow<'a, [u8]>,
+    pos: usize,
+}
+
+impl<'a> Parser<'a> {
+    fn new(full_text: Cow<'a, [u8]>) -> Parser<'a> {
+        Parser { full_text, pos: 0 }
+    }
+
+    fn peek(&self) -> u8 {
+        self.full_text[self.pos]
+    }
+
+    fn parse_label(&mut self) -> Result<Cow<'a, str>, String> {
+        assert!(self.pos == 0);
+        self.parse_separator_terminated_text()
+    }
+
+    fn parse_separator_terminated_text(&mut self) -> Result<Cow<'a, str>, String> {
+        let start = self.pos;
+
+        let end = memchr(SEPARATOR, &self.full_text[start..])
+            .map(|pos| pos + start)
+            .unwrap_or(self.full_text.len());
+
+        if start == end {
+            return self.err("Zero-length <text>");
+        }
+
+        self.pos = end;
+
+        Ok(self.substring(start, end))
+    }
+
+    fn parse_arg(&mut self) -> Result<Cow<'a, str>, String> {
+        if self.peek() != SEPARATOR {
+            return self.err(&format!(
+                "Expected '\\x{:x}' char at start of <argument>",
+                SEPARATOR
+            ));
+        }
+
+        self.pos += 1;
+        let tag = self.peek();
+
+        match tag {
+            ARG_TAG => {
+                self.pos += 1;
+                self.parse_separator_terminated_text()
+            }
+            other => self.err(&format!("Unexpected argument tag '{:x}'", other)),
+        }
+    }
+
+    fn err<T>(&self, message: &str) -> Result<T, String> {
+        Err(format!(
+            r#"Could not parse `event_id`. {} at {} in "{}""#,
+            message,
+            self.pos,
+            std::str::from_utf8(&self.full_text[..]).unwrap()
+        ))
+    }
+
+    fn substring(&self, start: usize, end: usize) -> Cow<'a, str> {
+        match self.full_text {
+            Cow::Owned(ref s) => {
+                let bytes = s[start..end].to_owned();
+                Cow::Owned(String::from_utf8(bytes).unwrap())
+            }
+            Cow::Borrowed(s) => Cow::Borrowed(std::str::from_utf8(&s[start..end]).unwrap()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::borrow::Cow;
+
+    #[test]
+    fn parse_event_id_no_args() {
+        let (label, args) = Event::parse_event_id(Cow::from("foo"));
+
+        assert_eq!(label, "foo");
+        assert!(args.is_empty());
+    }
+
+    #[test]
+    fn parse_event_id_one_arg() {
+        let (label, args) = Event::parse_event_id(Cow::from("foo\x1e\x11my_arg"));
+
+        assert_eq!(label, "foo");
+        assert_eq!(args, vec![Cow::from("my_arg")]);
+    }
+
+    #[test]
+    fn parse_event_id_n_args() {
+        let (label, args) =
+            Event::parse_event_id(Cow::from("foo\x1e\x11arg1\x1e\x11arg2\x1e\x11arg3"));
+
+        assert_eq!(label, "foo");
+        assert_eq!(
+            args,
+            vec![Cow::from("arg1"), Cow::from("arg2"), Cow::from("arg3")]
+        );
     }
 }

--- a/analyzeme/src/profiling_data.rs
+++ b/analyzeme/src/profiling_data.rs
@@ -1,7 +1,7 @@
 use crate::event::Event;
 use crate::lightweight_event::LightweightEvent;
-use crate::StringTable;
 use crate::timestamp::Timestamp;
+use crate::StringTable;
 use measureme::file_header::{
     read_file_header, write_file_header, CURRENT_FILE_FORMAT_VERSION, FILE_HEADER_SIZE,
     FILE_MAGIC_EVENT_STREAM,
@@ -94,10 +94,14 @@ impl ProfilingData {
 
         let timestamp = Timestamp::from_raw_event(&raw_event, self.metadata.start_time);
 
+        let event_id = string_table.get(raw_event.event_id).to_string();
+        // Parse out the label and arguments from the `event_id`.
+        let (label, additional_data) = Event::parse_event_id(event_id);
+
         Event {
             event_kind: string_table.get(raw_event.event_kind).to_string(),
-            label: string_table.get(raw_event.event_id).to_string(),
-            additional_data: &[],
+            label,
+            additional_data,
             timestamp,
             thread_id: raw_event.thread_id,
         }
@@ -319,7 +323,7 @@ mod tests {
         Event {
             event_kind: Cow::from(event_kind),
             label: Cow::from(label),
-            additional_data: &[],
+            additional_data: Vec::new(),
             timestamp: Timestamp::Interval {
                 start: SystemTime::UNIX_EPOCH + Duration::from_nanos(start_nanos),
                 end: SystemTime::UNIX_EPOCH + Duration::from_nanos(end_nanos),
@@ -337,7 +341,7 @@ mod tests {
         Event {
             event_kind: Cow::from(event_kind),
             label: Cow::from(label),
-            additional_data: &[],
+            additional_data: Vec::new(),
             timestamp: Timestamp::Instant(
                 SystemTime::UNIX_EPOCH + Duration::from_nanos(timestamp_nanos),
             ),
@@ -399,7 +403,6 @@ mod tests {
         assert_eq!(events[0].to_event(), full_interval("k1", "id1", 0, 10, 100));
         assert_eq!(events[1].to_event(), full_interval("k2", "id2", 1, 100, 110));
         assert_eq!(events[2].to_event(), full_interval("k3", "id3", 0, 120, 140));
-
     }
 
     #[test]

--- a/analyzeme/src/stringtable.rs
+++ b/analyzeme/src/stringtable.rs
@@ -7,10 +7,10 @@ use measureme::file_header::{
 };
 use measureme::stringtable::{METADATA_STRING_ID, STRING_ID_MASK, TERMINATOR};
 use measureme::{Addr, StringId};
+use memchr::memchr;
 use rustc_hash::FxHashMap;
 use std::borrow::Cow;
 use std::error::Error;
-use memchr::memchr;
 
 fn deserialize_index_entry(bytes: &[u8]) -> (StringId, Addr) {
     (

--- a/measureme/src/event_id.rs
+++ b/measureme/src/event_id.rs
@@ -13,9 +13,38 @@ use crate::{Profiler, SerializationSink, StringComponent, StringId};
 /// arguments. Future versions my support other optional suffixes (with a tag
 /// other than '\x11' after the '\x1E' separator), such as a "category".
 
-
 /// The byte used to separate arguments from the label and each other.
 pub const SEPARATOR_BYTE: &str = "\x1E";
+
+/// An `EventId` is a `StringId` with the additional guarantee that the
+/// corresponding string conforms to the event_id grammar.
+#[derive(Clone, Copy, Eq, PartialEq, Hash, Debug)]
+#[repr(C)]
+pub struct EventId(StringId);
+
+impl EventId {
+    pub const INVALID: EventId = EventId(StringId::INVALID);
+
+    #[inline]
+    pub fn to_string_id(self) -> StringId {
+        self.0
+    }
+
+    #[inline]
+    pub fn as_u32(self) -> u32 {
+        self.0.as_u32()
+    }
+
+    #[inline]
+    pub fn from_label(label: StringId) -> EventId {
+        EventId(label)
+    }
+
+    #[inline]
+    pub fn from_virtual(virtual_id: StringId) -> EventId {
+        EventId(virtual_id)
+    }
+}
 
 pub struct EventIdBuilder<'p, S: SerializationSink> {
     profiler: &'p Profiler<S>,
@@ -26,19 +55,20 @@ impl<'p, S: SerializationSink> EventIdBuilder<'p, S> {
         EventIdBuilder { profiler }
     }
 
-    pub fn from_label(&self, label: StringId) -> StringId {
-        // Just forward the string ID, i single identifier is a valid event_id
-        label
+    #[inline]
+    pub fn from_label(&self, label: StringId) -> EventId {
+        // Just forward the string ID, a single identifier is a valid event_id
+        EventId::from_label(label)
     }
 
-    pub fn from_label_and_arg(&self, label: StringId, arg: StringId) -> StringId {
-        self.profiler.alloc_string(&[
+    pub fn from_label_and_arg(&self, label: StringId, arg: StringId) -> EventId {
+        EventId(self.profiler.alloc_string(&[
             // Label
             StringComponent::Ref(label),
             // Seperator and start tag for arg
             StringComponent::Value(SEPARATOR_BYTE),
             // Arg string id
             StringComponent::Ref(arg),
-        ])
+        ]))
     }
 }

--- a/measureme/src/event_id.rs
+++ b/measureme/src/event_id.rs
@@ -1,0 +1,40 @@
+use crate::{Profiler, SerializationSink, StringComponent, StringId};
+
+/// Event IDs are strings conforming to the following grammar:
+///
+/// ```ignore
+///   <event_id> = <label> {<argument>}
+///   <label> = <text>
+///   <argument> = '\x1E' '\x11' <text>
+///   <text> = regex([^0x1E]+) // Anything but the separator byte
+///  ```
+///
+/// This means there's always a "label", followed by an optional list of
+/// arguments. Future versions my support other optional suffixes (with a tag
+/// other than '\x11' after the '\x1E' separator), such as a "category".
+
+pub struct EventIdBuilder<'p, S: SerializationSink> {
+    profiler: &'p Profiler<S>,
+}
+
+impl<'p, S: SerializationSink> EventIdBuilder<'p, S> {
+    pub fn new(profiler: &Profiler<S>) -> EventIdBuilder<'_, S> {
+        EventIdBuilder { profiler }
+    }
+
+    pub fn from_label(&self, label: StringId) -> StringId {
+        // Just forward the string ID, i single identifier is a valid event_id
+        label
+    }
+
+    pub fn from_label_and_arg(&self, label: StringId, arg: StringId) -> StringId {
+        self.profiler.alloc_string(&[
+            // Label
+            StringComponent::Ref(label),
+            // Seperator and start tag for arg
+            StringComponent::Value("\x1E\x11"),
+            // Arg string id
+            StringComponent::Ref(arg),
+        ])
+    }
+}

--- a/measureme/src/event_id.rs
+++ b/measureme/src/event_id.rs
@@ -5,13 +5,17 @@ use crate::{Profiler, SerializationSink, StringComponent, StringId};
 /// ```ignore
 ///   <event_id> = <label> {<argument>}
 ///   <label> = <text>
-///   <argument> = '\x1E' '\x11' <text>
-///   <text> = regex([^0x1E]+) // Anything but the separator byte
+///   <argument> = '\x1E' <text>
+///   <text> = regex([^[[:cntrl:]]]+) // Anything but ASCII control characters
 ///  ```
 ///
 /// This means there's always a "label", followed by an optional list of
 /// arguments. Future versions my support other optional suffixes (with a tag
 /// other than '\x11' after the '\x1E' separator), such as a "category".
+
+
+/// The byte used to separate arguments from the label and each other.
+pub const SEPARATOR_BYTE: &str = "\x1E";
 
 pub struct EventIdBuilder<'p, S: SerializationSink> {
     profiler: &'p Profiler<S>,
@@ -32,7 +36,7 @@ impl<'p, S: SerializationSink> EventIdBuilder<'p, S> {
             // Label
             StringComponent::Ref(label),
             // Seperator and start tag for arg
-            StringComponent::Value("\x1E\x11"),
+            StringComponent::Value(SEPARATOR_BYTE),
             // Arg string id
             StringComponent::Ref(arg),
         ])

--- a/measureme/src/file_header.rs
+++ b/measureme/src/file_header.rs
@@ -6,7 +6,7 @@ use crate::serialization::SerializationSink;
 use byteorder::{ByteOrder, LittleEndian};
 use std::error::Error;
 
-pub const CURRENT_FILE_FORMAT_VERSION: u32 = 4;
+pub const CURRENT_FILE_FORMAT_VERSION: u32 = 5;
 pub const FILE_MAGIC_EVENT_STREAM: &[u8; 4] = b"MMES";
 pub const FILE_MAGIC_STRINGTABLE_DATA: &[u8; 4] = b"MMSD";
 pub const FILE_MAGIC_STRINGTABLE_INDEX: &[u8; 4] = b"MMSI";

--- a/measureme/src/lib.rs
+++ b/measureme/src/lib.rs
@@ -50,7 +50,7 @@ pub mod stringtable;
 
 pub mod rustc;
 
-pub use crate::event_id::EventIdBuilder;
+pub use crate::event_id::{EventId, EventIdBuilder};
 #[cfg(any(not(target_arch = "wasm32"), target_os = "wasi"))]
 pub use crate::file_serialization_sink::FileSerializationSink;
 #[cfg(not(target_arch = "wasm32"))]

--- a/measureme/src/lib.rs
+++ b/measureme/src/lib.rs
@@ -37,6 +37,7 @@
 
 #![deny(warnings)]
 
+mod event_id;
 pub mod file_header;
 #[cfg(any(not(target_arch = "wasm32"), target_os = "wasi"))]
 mod file_serialization_sink;
@@ -49,6 +50,7 @@ pub mod stringtable;
 
 pub mod rustc;
 
+pub use crate::event_id::EventIdBuilder;
 #[cfg(any(not(target_arch = "wasm32"), target_os = "wasi"))]
 pub use crate::file_serialization_sink::FileSerializationSink;
 #[cfg(not(target_arch = "wasm32"))]

--- a/measureme/src/lib.rs
+++ b/measureme/src/lib.rs
@@ -37,7 +37,7 @@
 
 #![deny(warnings)]
 
-mod event_id;
+pub mod event_id;
 pub mod file_header;
 #[cfg(any(not(target_arch = "wasm32"), target_os = "wasi"))]
 mod file_serialization_sink;

--- a/measureme/src/profiler.rs
+++ b/measureme/src/profiler.rs
@@ -1,3 +1,4 @@
+use crate::event_id::EventId;
 use crate::file_header::{write_file_header, FILE_MAGIC_EVENT_STREAM};
 use crate::raw_event::RawEvent;
 use crate::serialization::SerializationSink;
@@ -92,7 +93,7 @@ impl<S: SerializationSink> Profiler<S> {
 
     /// Records an event with the given parameters. The event time is computed
     /// automatically.
-    pub fn record_instant_event(&self, event_kind: StringId, event_id: StringId, thread_id: u32) {
+    pub fn record_instant_event(&self, event_kind: StringId, event_id: EventId, thread_id: u32) {
         let raw_event =
             RawEvent::new_instant(event_kind, event_id, thread_id, self.nanos_since_start());
 
@@ -105,7 +106,7 @@ impl<S: SerializationSink> Profiler<S> {
     pub fn start_recording_interval_event<'a>(
         &'a self,
         event_kind: StringId,
-        event_id: StringId,
+        event_id: EventId,
         thread_id: u32,
     ) -> TimingGuard<'a, S> {
         TimingGuard {
@@ -135,7 +136,7 @@ impl<S: SerializationSink> Profiler<S> {
 #[must_use]
 pub struct TimingGuard<'a, S: SerializationSink> {
     profiler: &'a Profiler<S>,
-    event_id: StringId,
+    event_id: EventId,
     event_kind: StringId,
     thread_id: u32,
     start_ns: u64,
@@ -157,11 +158,10 @@ impl<'a, S: SerializationSink> Drop for TimingGuard<'a, S> {
 }
 
 impl<'a, S: SerializationSink> TimingGuard<'a, S> {
-
     /// This method set a new `event_id` right before actually recording the
     /// event.
     #[inline]
-    pub fn finish_with_override_event_id(mut self, event_id: StringId) {
+    pub fn finish_with_override_event_id(mut self, event_id: EventId) {
         self.event_id = event_id;
         // Let's be explicit about it: Dropping the guard will record the event.
         drop(self)

--- a/measureme/src/raw_event.rs
+++ b/measureme/src/raw_event.rs
@@ -1,3 +1,4 @@
+use crate::event_id::EventId;
 use crate::stringtable::StringId;
 
 /// `RawEvent` is how events are stored on-disk. If you change this struct,
@@ -6,7 +7,7 @@ use crate::stringtable::StringId;
 #[repr(C)]
 pub struct RawEvent {
     pub event_kind: StringId,
-    pub event_id: StringId,
+    pub event_id: EventId,
     pub thread_id: u32,
 
     // The following 96 bits store the start and the end timestamp, using
@@ -30,7 +31,7 @@ impl RawEvent {
     #[inline]
     pub fn new_interval(
         event_kind: StringId,
-        event_id: StringId,
+        event_id: EventId,
         thread_id: u32,
         start_nanos: u64,
         end_nanos: u64,
@@ -59,7 +60,7 @@ impl RawEvent {
     #[inline]
     pub fn new_instant(
         event_kind: StringId,
-        event_id: StringId,
+        event_id: EventId,
         thread_id: u32,
         timestamp_ns: u64,
     ) -> RawEvent {
@@ -163,7 +164,7 @@ impl Default for RawEvent {
     fn default() -> Self {
         RawEvent {
             event_kind: StringId::INVALID,
-            event_id: StringId::INVALID,
+            event_id: EventId::INVALID,
             thread_id: 0,
             start_time_lower: 0,
             end_time_lower: 0,
@@ -184,11 +185,11 @@ mod tests {
 
     #[test]
     fn is_instant() {
-        assert!(RawEvent::new_instant(StringId::INVALID, StringId::INVALID, 987, 0,).is_instant());
+        assert!(RawEvent::new_instant(StringId::INVALID, EventId::INVALID, 987, 0,).is_instant());
 
         assert!(RawEvent::new_instant(
             StringId::INVALID,
-            StringId::INVALID,
+            EventId::INVALID,
             987,
             MAX_INSTANT_TIMESTAMP,
         )
@@ -196,7 +197,7 @@ mod tests {
 
         assert!(!RawEvent::new_interval(
             StringId::INVALID,
-            StringId::INVALID,
+            EventId::INVALID,
             987,
             0,
             MAX_INTERVAL_TIMESTAMP,
@@ -209,7 +210,7 @@ mod tests {
     fn invalid_instant_timestamp() {
         let _ = RawEvent::new_instant(
             StringId::INVALID,
-            StringId::INVALID,
+            EventId::INVALID,
             123,
             // timestamp too large
             MAX_INSTANT_TIMESTAMP + 1,
@@ -221,7 +222,7 @@ mod tests {
     fn invalid_start_timestamp() {
         let _ = RawEvent::new_interval(
             StringId::INVALID,
-            StringId::INVALID,
+            EventId::INVALID,
             123,
             // start timestamp too large
             MAX_INTERVAL_TIMESTAMP + 1,
@@ -234,7 +235,7 @@ mod tests {
     fn invalid_end_timestamp() {
         let _ = RawEvent::new_interval(
             StringId::INVALID,
-            StringId::INVALID,
+            EventId::INVALID,
             123,
             0,
             // end timestamp too large
@@ -247,7 +248,7 @@ mod tests {
     fn invalid_end_timestamp2() {
         let _ = RawEvent::new_interval(
             StringId::INVALID,
-            StringId::INVALID,
+            EventId::INVALID,
             123,
             0,
             INSTANT_TIMESTAMP_MARKER,
@@ -259,7 +260,7 @@ mod tests {
     fn start_greater_than_end_timestamp() {
         let _ = RawEvent::new_interval(
             StringId::INVALID,
-            StringId::INVALID,
+            EventId::INVALID,
             123,
             // start timestamp greater than end timestamp
             1,
@@ -270,7 +271,7 @@ mod tests {
     #[test]
     fn start_equal_to_end_timestamp() {
         // This is allowed, make sure we don't panic
-        let _ = RawEvent::new_interval(StringId::INVALID, StringId::INVALID, 123, 1, 1);
+        let _ = RawEvent::new_interval(StringId::INVALID, EventId::INVALID, 123, 1, 1);
     }
 
     #[test]
@@ -278,7 +279,7 @@ mod tests {
         // Check the upper limits
         let e = RawEvent::new_interval(
             StringId::INVALID,
-            StringId::INVALID,
+            EventId::INVALID,
             1234,
             MAX_INTERVAL_TIMESTAMP,
             MAX_INTERVAL_TIMESTAMP,
@@ -288,7 +289,7 @@ mod tests {
         assert_eq!(e.end_nanos(), MAX_INTERVAL_TIMESTAMP);
 
         // Check the lower limits
-        let e = RawEvent::new_interval(StringId::INVALID, StringId::INVALID, 1234, 0, 0);
+        let e = RawEvent::new_interval(StringId::INVALID, EventId::INVALID, 1234, 0, 0);
 
         assert_eq!(e.start_nanos(), 0);
         assert_eq!(e.end_nanos(), 0);
@@ -296,7 +297,7 @@ mod tests {
         // Check that end does not bleed into start
         let e = RawEvent::new_interval(
             StringId::INVALID,
-            StringId::INVALID,
+            EventId::INVALID,
             1234,
             0,
             MAX_INTERVAL_TIMESTAMP,
@@ -308,7 +309,7 @@ mod tests {
         // Test some random values
         let e = RawEvent::new_interval(
             StringId::INVALID,
-            StringId::INVALID,
+            EventId::INVALID,
             1234,
             0x1234567890,
             0x1234567890A,
@@ -321,14 +322,14 @@ mod tests {
     #[test]
     fn instant_timestamp_decoding() {
         assert_eq!(
-            RawEvent::new_instant(StringId::INVALID, StringId::INVALID, 987, 0,).start_nanos(),
+            RawEvent::new_instant(StringId::INVALID, EventId::INVALID, 987, 0,).start_nanos(),
             0
         );
 
         assert_eq!(
             RawEvent::new_instant(
                 StringId::INVALID,
-                StringId::INVALID,
+                EventId::INVALID,
                 987,
                 MAX_INSTANT_TIMESTAMP,
             )


### PR DESCRIPTION
This is implemented by encoding arguments as part of the `event_id` using the following grammar:

```
<event_id> = <label> {<argument>}
<label> = <text>
<argument> = '\x1E' <text>
<text> = regex([^[[:cntrl:]]]+) // Anything but ASCII control characters
```

This can be extended in the future to also encode the "category" that specify in `rustc` but don't use anywhere. The grammar uses ASCII control characters as separators. I'm not sure how much I like the grammar. It's something that works for now but I don't consider it great.

I'm debating whether `event_id` should get a new type `struct EventId(StringId)`. That way we could ensure at compile time that only syntactically correct strings are used as `event_id`s...

r? @wesleywiser 