### PR TITLE
Fix big-endian build and add CI tests for it.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,15 @@
 language: rust
+before_install:
+  - rustup target add powerpc64-unknown-linux-gnu
 rust:
   - stable
   - beta
   - nightly
+fast_finish: true
+env:
+  - CARGO_INCREMENTAL=0
+install: skip
+script:
+  - cargo check --verbose --target powerpc64-unknown-linux-gnu --lib --bins --tests || exit 1
+  - cargo build --verbose --all || exit 1
+  - cargo test --verbose --all

--- a/analyzeme/Cargo.toml
+++ b/analyzeme/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "analyzeme"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Wesley Wiser <wwiser@gmail.com>", "Michael Woerister <michaelwoerister@posteo>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/crox/Cargo.toml
+++ b/crox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crox"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Wesley Wiser <wwiser@gmail.com>"]
 edition = "2018"
 

--- a/flamegraph/Cargo.toml
+++ b/flamegraph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flamegraph"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Wesley Wiser <wwiser@gmail.com>", "Michael Woerister <michaelwoerister@posteo>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/measureme/Cargo.toml
+++ b/measureme/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "measureme"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Wesley Wiser <wwiser@gmail.com>", "Michael Woerister <michaelwoerister@posteo>"]
 edition = "2018"
 description = "Support crate for rustc's self-profiling feature"

--- a/measureme/src/event_id.rs
+++ b/measureme/src/event_id.rs
@@ -44,6 +44,13 @@ impl EventId {
     pub fn from_virtual(virtual_id: StringId) -> EventId {
         EventId(virtual_id)
     }
+
+    /// Create an EventId from a raw u32 value. Only used internally for
+    /// deserialization.
+    #[inline]
+    pub fn from_u32(raw_id: u32) -> EventId {
+        EventId(StringId::new(raw_id))
+    }
 }
 
 pub struct EventIdBuilder<'p, S: SerializationSink> {

--- a/measureme/src/raw_event.rs
+++ b/measureme/src/raw_event.rs
@@ -149,8 +149,8 @@ impl RawEvent {
         {
             use byteorder::{ByteOrder, LittleEndian};
             RawEvent {
-                event_kind: StringId::reserved(LittleEndian::read_u32(&bytes[0..])),
-                event_id: StringId::reserved(LittleEndian::read_u32(&bytes[4..])),
+                event_kind: StringId::new(LittleEndian::read_u32(&bytes[0..])),
+                event_id: EventId::from_u32(LittleEndian::read_u32(&bytes[4..])),
                 thread_id: LittleEndian::read_u32(&bytes[8..]),
                 start_time_lower: LittleEndian::read_u32(&bytes[12..]),
                 end_time_lower: LittleEndian::read_u32(&bytes[16..]),

--- a/mmview/Cargo.toml
+++ b/mmview/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mmview"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Wesley Wiser <wwiser@gmail.com>", "Michael Woerister <michaelwoerister@posteo>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/stack_collapse/Cargo.toml
+++ b/stack_collapse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stack_collapse"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Wesley Wiser <wwiser@gmail.com>", "Michael Woerister <michaelwoerister@posteo>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/summarize/Cargo.toml
+++ b/summarize/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "summarize"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Wesley Wiser <wwiser@gmail.com>", "Michael Woerister <michaelwoerister@posteo>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
This PR

- fixes a compilation error on big endian platforms
- adds a big endian `cargo check` build to CI, so we catch compilation errors like these early next time
- bumps the version to `0.7.1` so we can use that to unblock https://github.com/rust-lang/rust/pull/67397.

~~This PR should fail until the big endian specific error uncovered [here](https://github.com/rust-lang/rust/pull/67397#issuecomment-568295509) is fixed.~~