### PR TITLE
add additinonal data to crox events

### DIFF
--- a/crox/src/main.rs
+++ b/crox/src/main.rs
@@ -116,6 +116,21 @@ fn generate_thread_to_collapsed_thread_mapping(
     thread_to_collapsed_thread
 }
 
+fn get_args(full_event: &analyzeme::Event) -> Option<FxHashMap<String, String>> {
+    if !full_event.additional_data.is_empty() {
+        Some(
+            full_event
+                .additional_data
+                .iter()
+                .enumerate()
+                .map(|(i, arg)| (format!("arg{}", i).to_string(), arg.to_string()))
+                .collect(),
+        )
+    } else {
+        None
+    }
+}
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let opt = Opt::from_args();
 
@@ -151,7 +166,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 thread_id: *thread_to_collapsed_thread
                     .get(&event.thread_id)
                     .unwrap_or(&event.thread_id),
-                args: None,
+                args: get_args(&full_event),
             };
             seq.serialize_element(&crox_event)?;
         }


### PR DESCRIPTION
hade been nice to have some reserved names (eg. def_id, cgu_id ...) for the additional data now I have only enumerated them.

eg. of how it looks in chrome://tracing/
![image](https://user-images.githubusercontent.com/844398/72291819-74052800-3650-11ea-83e4-378d99fe005a.png)
 