### PR TITLE
In-memory construction of profiling data

### DIFF
--- a/analyzeme/src/profiling_data.rs
+++ b/analyzeme/src/profiling_data.rs
@@ -52,6 +52,17 @@ impl ProfilingData {
             fs::read(paths.string_index_file).expect("couldn't read string_index file");
         let event_data = fs::read(paths.events_file).expect("couldn't read events file");
 
+        ProfilingData::from_buffers(string_data, index_data, event_data)
+    }
+
+    pub fn from_buffers(
+        string_data: Vec<u8>,
+        string_index: Vec<u8>,
+        events: Vec<u8>,
+    ) -> Result<ProfilingData, Box<dyn Error>> {
+        let index_data = string_index;
+        let event_data = events;
+
         let event_data_format = read_file_header(&event_data, FILE_MAGIC_EVENT_STREAM)?;
         if event_data_format != CURRENT_FILE_FORMAT_VERSION {
             Err(format!(


### PR DESCRIPTION
perf.rust-lang.org is using this to avoid writing out profiles to disk when loading them over the network.