### PR TITLE
Update README for changes in x.py defaults

### DIFF
--- a/summarize/Readme.md
+++ b/summarize/Readme.md
@@ -80,7 +80,7 @@ You can also profile your own custom build of rustc. First you'll have to clone 
 
 ```bash
 $ git clone https://github.com/rust-lang/rust.git
-$ ./x.py build
+$ ./x.py build --stage 2
 # This will take a while...
 $ rustup toolchain link mytoolchain build/x86_64-unknown-linux-gnu/stage2
 ```

--- a/summarize/Readme.md
+++ b/summarize/Readme.md
@@ -80,9 +80,9 @@ You can also profile your own custom build of rustc. First you'll have to clone 
 
 ```bash
 $ git clone https://github.com/rust-lang/rust.git
-$ ./x.py build --stage 2
+$ ./x.py build
 # This will take a while...
-$ rustup toolchain link mytoolchain build/x86_64-unknown-linux-gnu/stage2
+$ rustup toolchain link mytoolchain build/x86_64-unknown-linux-gnu/stage1
 ```
 
 Where `mytoolchain` is the name of your custom toolchain. Now we do more or less the same


### PR DESCRIPTION
See https://github.com/rust-lang/rust/pull/73964.

The choices are either to link to `stage1` with rustup or build stage 2; this recommends to build stage2 to be consistent with the existing docs.