### PR TITLE
Remove byteorder dependency

### DIFF
--- a/analyzeme/src/stringtable.rs
+++ b/analyzeme/src/stringtable.rs
@@ -1,6 +1,5 @@
 //! See module-level documentation `measureme::stringtable`.
 
-use byteorder::{BigEndian, ByteOrder, LittleEndian};
 use measureme::file_header::{
     read_file_header, strip_file_header, CURRENT_FILE_FORMAT_VERSION, FILE_MAGIC_STRINGTABLE_DATA,
     FILE_MAGIC_STRINGTABLE_INDEX,
@@ -10,12 +9,13 @@ use measureme::{Addr, StringId};
 use memchr::memchr;
 use rustc_hash::FxHashMap;
 use std::borrow::Cow;
+use std::convert::TryInto;
 use std::error::Error;
 
 fn deserialize_index_entry(bytes: &[u8]) -> (StringId, Addr) {
     (
-        StringId::new(LittleEndian::read_u32(&bytes[0..4])),
-        Addr(LittleEndian::read_u32(&bytes[4..8])),
+        StringId::new(u32::from_le_bytes(bytes[0..4].try_into().unwrap())),
+        Addr(u32::from_le_bytes(bytes[4..8].try_into().unwrap())),
     )
 }
 
@@ -138,7 +138,7 @@ fn is_utf8_continuation_byte(byte: u8) -> bool {
 // String IDs in the table data are encoded in big endian format, while string
 // IDs in the index are encoded in little endian format. Don't mix the two up.
 fn decode_string_id_from_data(bytes: &[u8]) -> StringId {
-    let id = BigEndian::read_u32(&bytes[0..4]);
+    let id = u32::from_be_bytes(bytes[0..4].try_into().unwrap());
     // Mask off the `0b10` prefix
     StringId::new(id & STRING_ID_MASK)
 }

--- a/measureme/src/file_header.rs
+++ b/measureme/src/file_header.rs
@@ -3,7 +3,7 @@
 //! number.
 
 use crate::serialization::SerializationSink;
-use byteorder::{ByteOrder, LittleEndian};
+use std::convert::TryInto;
 use std::error::Error;
 
 pub const CURRENT_FILE_FORMAT_VERSION: u32 = 5;
@@ -22,7 +22,7 @@ pub fn write_file_header<S: SerializationSink>(s: &S, file_magic: &[u8; 4]) {
 
     s.write_atomic(FILE_HEADER_SIZE, |bytes| {
         bytes[0..4].copy_from_slice(file_magic);
-        LittleEndian::write_u32(&mut bytes[4..8], CURRENT_FILE_FORMAT_VERSION);
+        bytes[4..8].copy_from_slice(&CURRENT_FILE_FORMAT_VERSION.to_le_bytes());
     });
 }
 
@@ -44,7 +44,7 @@ pub fn read_file_header(bytes: &[u8], expected_magic: &[u8; 4]) -> Result<u32, B
         return Err(From::from(msg));
     }
 
-    Ok(LittleEndian::read_u32(&bytes[4..8]))
+    Ok(u32::from_le_bytes(bytes[4..8].try_into().unwrap()))
 }
 
 pub fn strip_file_header(data: &[u8]) -> &[u8] {

--- a/measureme/src/profiler.rs
+++ b/measureme/src/profiler.rs
@@ -31,8 +31,7 @@ pub struct Profiler<S: SerializationSink> {
 }
 
 impl<S: SerializationSink> Profiler<S> {
-    pub fn new<P: AsRef<Path>>(path_stem: P)
-    -> Result<Profiler<S>, Box<dyn Error + Send + Sync>> {
+    pub fn new<P: AsRef<Path>>(path_stem: P) -> Result<Profiler<S>, Box<dyn Error + Send + Sync>> {
         let paths = ProfilerFiles::new(path_stem.as_ref());
         let event_sink = Arc::new(S::from_path(&paths.events_file)?);
 

--- a/measureme/src/stringtable.rs
+++ b/measureme/src/stringtable.rs
@@ -67,7 +67,6 @@ use crate::file_header::{
     write_file_header, FILE_MAGIC_STRINGTABLE_DATA, FILE_MAGIC_STRINGTABLE_INDEX,
 };
 use crate::serialization::{Addr, SerializationSink};
-// use byteorder::{BigEndian, ByteOrder};
 use std::sync::Arc;
 
 /// A `StringId` is used to identify a string in the `StringTable`. It is

--- a/measureme/src/stringtable.rs
+++ b/measureme/src/stringtable.rs
@@ -67,7 +67,7 @@ use crate::file_header::{
     write_file_header, FILE_MAGIC_STRINGTABLE_DATA, FILE_MAGIC_STRINGTABLE_INDEX,
 };
 use crate::serialization::{Addr, SerializationSink};
-use byteorder::{BigEndian, ByteOrder, LittleEndian};
+// use byteorder::{BigEndian, ByteOrder};
 use std::sync::Arc;
 
 /// A `StringId` is used to identify a string in the `StringTable`. It is
@@ -190,7 +190,7 @@ impl<'s> StringComponent<'s> {
                 assert!(string_id.0 == string_id.0 & STRING_ID_MASK);
                 let tagged = string_id.0 | (1u32 << 31);
 
-                BigEndian::write_u32(&mut bytes[0..4], tagged);
+                &mut bytes[0..4].copy_from_slice(&tagged.to_be_bytes());
                 &mut bytes[4..]
             }
         }
@@ -253,8 +253,8 @@ impl_serializable_string_for_fixed_size!(16);
 
 fn serialize_index_entry<S: SerializationSink>(sink: &S, id: StringId, addr: Addr) {
     sink.write_atomic(8, |bytes| {
-        LittleEndian::write_u32(&mut bytes[0..4], id.0);
-        LittleEndian::write_u32(&mut bytes[4..8], addr.0);
+        bytes[0..4].copy_from_slice(&id.0.to_le_bytes());
+        bytes[4..8].copy_from_slice(&addr.0.to_le_bytes());
     });
 }
 


### PR DESCRIPTION
In the interest of simplifying dependency management for measureme and ultimately rustc, this refactors measureme to remove its dependency on the byteorder crate.