### PR TITLE
summarize: add "aggregate" sub-command for analyzing sets of profiles.

### DIFF
--- a/summarize/src/aggregate.rs
+++ b/summarize/src/aggregate.rs
@@ -544,7 +544,7 @@ pub fn aggregate_profiles(profiles: Vec<ProfilingData>) {
             describe(descriptions)
         );
     }
-    println!("");
+    println!();
     println!("Largest {} variances:", variances.largest.len());
     for (variance, descriptions) in variances.largest {
         println!(

--- a/summarize/src/aggregate.rs
+++ b/summarize/src/aggregate.rs
@@ -1,0 +1,556 @@
+mod backwards_iter {
+    // HACK(eddyb) like `DoubleEndedIterator`, but without a (forwards) `Iterator`.
+    // This is needed because of how events are stored in "postorder",
+    // i.e. an interval event follows all events nested in it, meaning
+    // that most analyses we want to do can only be done in reverse.
+    pub trait BackwardsIterator {
+        type Item;
+        fn next_back(&mut self) -> Option<Self::Item>;
+    }
+
+    pub struct Rev<I>(I);
+
+    pub trait BackwardsIteratorExt: Sized {
+        fn rev(self) -> Rev<Self>;
+    }
+
+    impl<I: BackwardsIterator> BackwardsIteratorExt for I {
+        fn rev(self) -> Rev<Self> {
+            Rev(self)
+        }
+    }
+
+    impl<I: BackwardsIterator> Iterator for Rev<I> {
+        type Item = I::Item;
+        fn next(&mut self) -> Option<I::Item> {
+            self.0.next_back()
+        }
+    }
+}
+
+use self::backwards_iter::{BackwardsIterator, BackwardsIteratorExt as _};
+use analyzeme::{Event, ProfilingData, Timestamp};
+use measureme::rustc::*;
+use std::borrow::Cow;
+use std::collections::BTreeMap;
+use std::fmt;
+use std::time::{Duration, SystemTime};
+
+// FIXME(eddyb) move this into `analyzeme`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EventDescription<'a> {
+    pub event_kind: Cow<'a, str>,
+    pub label: Cow<'a, str>,
+    pub additional_data: Vec<Cow<'a, str>>,
+}
+
+impl<'a> From<Event<'a>> for EventDescription<'a> {
+    fn from(e: Event<'a>) -> Self {
+        EventDescription {
+            event_kind: e.event_kind,
+            label: e.label,
+            additional_data: e.additional_data,
+        }
+    }
+}
+
+impl fmt::Display for EventDescription<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.event_kind[..] {
+            QUERY_EVENT_KIND | GENERIC_ACTIVITY_EVENT_KIND => {}
+            _ => write!(f, "{} ", self.event_kind)?,
+        }
+
+        write!(f, "`{}(", self.label)?;
+        for (i, arg) in self.additional_data.iter().enumerate() {
+            if i > 0 {
+                write!(f, ", ")?;
+            }
+            write!(f, "{}", arg)?;
+        }
+        write!(f, ")`")
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WithParent<T> {
+    this: T,
+    parent: Option<T>,
+}
+
+impl<'a> From<WithParent<Event<'a>>> for WithParent<EventDescription<'a>> {
+    fn from(e: WithParent<Event<'a>>) -> Self {
+        WithParent {
+            this: e.this.into(),
+            parent: e.parent.map(|e| e.into()),
+        }
+    }
+}
+
+// FIXME(eddyb) should all these variants have `E` in them? seems un-DRY
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum SamplePoint<E> {
+    Start(E),
+    End(E),
+    Instant(E),
+}
+
+impl<E> SamplePoint<E> {
+    fn event(&self) -> &E {
+        match self {
+            SamplePoint::Start(event) | SamplePoint::End(event) | SamplePoint::Instant(event) => {
+                event
+            }
+        }
+    }
+
+    fn map_event<E2>(self, f: impl FnOnce(E) -> E2) -> SamplePoint<E2> {
+        match self {
+            SamplePoint::Start(event) => SamplePoint::Start(f(event)),
+            SamplePoint::End(event) => SamplePoint::End(f(event)),
+            SamplePoint::Instant(event) => SamplePoint::Instant(f(event)),
+        }
+    }
+}
+
+impl SamplePoint<WithParent<Event<'_>>> {
+    fn timestamp(&self) -> SystemTime {
+        match (self, self.event().this.timestamp) {
+            (SamplePoint::Start(_), Timestamp::Interval { start, .. }) => start,
+            (SamplePoint::End(_), Timestamp::Interval { end, .. }) => end,
+            (SamplePoint::Instant(_), Timestamp::Instant(time)) => time,
+            _ => panic!(
+                "SamplePoint::timestamp: event timestamp doesn't match \
+                 `SamplePoint` variant, in `SamplePoint::{:?}`",
+                self
+            ),
+        }
+    }
+}
+
+struct SamplePoints<'a, I: DoubleEndedIterator<Item = Event<'a>>> {
+    /// This analysis only works with deterministic runs, which precludes parallelism,
+    /// so we just have to find the *only* thread's ID and require there is no other.
+    expected_thread_id: u32,
+
+    rev_events: std::iter::Peekable<std::iter::Rev<I>>,
+    stack: Vec<Event<'a>>,
+}
+
+impl<'a, I: DoubleEndedIterator<Item = Event<'a>>> SamplePoints<'a, I> {
+    fn new(events: I) -> Self {
+        let mut rev_events = events.rev().peekable();
+        SamplePoints {
+            // The `0` default doesn't matter, if there are no events.
+            expected_thread_id: rev_events.peek().map_or(0, |event| event.thread_id),
+
+            rev_events,
+            stack: vec![],
+        }
+    }
+
+    fn intervals(self) -> SampleIntervals<Self> {
+        SampleIntervals::new(self)
+    }
+}
+
+impl<'a, I: DoubleEndedIterator<Item = Event<'a>>> BackwardsIterator for SamplePoints<'a, I> {
+    type Item = SamplePoint<WithParent<Event<'a>>>;
+    fn next_back(&mut self) -> Option<Self::Item> {
+        let sample_point = match self.rev_events.peek() {
+            Some(peeked_event) => {
+                assert_eq!(
+                    peeked_event.thread_id, self.expected_thread_id,
+                    "more than one thread is not supported in `summarize aggregate`"
+                );
+                match self.stack.last() {
+                    // Make sure to first leave any events in the stack that succeed
+                    // this one (note that because we're `peek`-ing, this will keep
+                    // getting hit until we run out of stack entries to leave).
+                    Some(top_event) if !top_event.contains(peeked_event) => {
+                        SamplePoint::Start(self.stack.pop().unwrap())
+                    }
+
+                    _ => {
+                        let event = self.rev_events.next().unwrap();
+                        match event.timestamp {
+                            Timestamp::Interval { .. } => {
+                                // Now entering this new event.
+                                self.stack.push(event.clone());
+                                SamplePoint::End(event)
+                            }
+
+                            Timestamp::Instant(_) => SamplePoint::Instant(event),
+                        }
+                    }
+                }
+            }
+
+            // Ran out of events, but we might still have stack entries to leave.
+            None => SamplePoint::Start(self.stack.pop()?),
+        };
+
+        // HACK(eddyb) this works around `SamplePoint::End` having pushed itself
+        // onto the stack, so its parent isn't the top of the stack anymore.
+        let parent = match sample_point {
+            SamplePoint::End(_) => {
+                if self.stack.len() >= 2 {
+                    Some(&self.stack[self.stack.len() - 2])
+                } else {
+                    None
+                }
+            }
+            SamplePoint::Start(_) | SamplePoint::Instant(_) => self.stack.last(),
+        };
+
+        Some(sample_point.map_event(|this| WithParent {
+            this,
+            parent: parent.cloned(),
+        }))
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct SampleInterval<E> {
+    start: SamplePoint<E>,
+    end: SamplePoint<E>,
+}
+
+impl<E> SampleInterval<E> {
+    fn map_event<E2>(self, f: impl Copy + FnOnce(E) -> E2) -> SampleInterval<E2> {
+        SampleInterval {
+            start: self.start.map_event(f),
+            end: self.end.map_event(f),
+        }
+    }
+}
+
+impl SampleInterval<WithParent<Event<'_>>> {
+    fn duration(&self) -> Duration {
+        self.end
+            .timestamp()
+            .duration_since(self.start.timestamp())
+            .unwrap()
+    }
+}
+
+struct SampleIntervals<I: BackwardsIterator> {
+    last_sample_point: Option<I::Item>,
+
+    sample_points: I,
+}
+
+impl<I: BackwardsIterator> SampleIntervals<I> {
+    fn new(mut sample_points: I) -> Self {
+        SampleIntervals {
+            last_sample_point: sample_points.next_back(),
+
+            sample_points,
+        }
+    }
+}
+
+impl<E: Clone, I: BackwardsIterator<Item = SamplePoint<E>>> BackwardsIterator
+    for SampleIntervals<I>
+{
+    type Item = SampleInterval<E>;
+    fn next_back(&mut self) -> Option<Self::Item> {
+        let start = self.sample_points.next_back()?;
+        // FIXME(eddyb) make this cloning cheaper (somehow?)
+        let end = self.last_sample_point.replace(start.clone())?;
+
+        Some(SampleInterval { start, end })
+    }
+}
+
+// FIXME(eddyb) extend this with more statistical information, rather
+// than assuming uniform distribution inside the range (`min..=max`).
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct Variance<T> {
+    /// The size of the range of possible values, i.e. `max - min`.
+    range_size: T,
+}
+
+struct AggregatedSampleInterval<'a> {
+    descriptions: SampleInterval<WithParent<EventDescription<'a>>>,
+
+    min_duration: Duration,
+    duration_variance: Variance<Duration>,
+}
+
+impl AggregatedSampleInterval<'_> {
+    fn max_duration(&self) -> Duration {
+        self.min_duration + self.duration_variance.range_size
+    }
+}
+
+struct AggregatedSampleIntervals<I> {
+    sample_intervals_per_profile: Vec<I>,
+}
+
+impl<'a, I: BackwardsIterator<Item = SampleInterval<WithParent<Event<'a>>>>>
+    AggregatedSampleIntervals<I>
+{
+    fn new(sample_intervals_per_profile: impl Iterator<Item = I>) -> Self {
+        AggregatedSampleIntervals {
+            sample_intervals_per_profile: sample_intervals_per_profile.collect(),
+        }
+    }
+}
+
+impl<'a, I: BackwardsIterator<Item = SampleInterval<WithParent<Event<'a>>>>> BackwardsIterator
+    for AggregatedSampleIntervals<I>
+{
+    type Item = AggregatedSampleInterval<'a>;
+    fn next_back(&mut self) -> Option<Self::Item> {
+        match self.sample_intervals_per_profile.get_mut(0)?.next_back() {
+            Some(interval) => {
+                let first_duration = interval.duration();
+                let descriptions = interval.map_event(WithParent::<EventDescription>::from);
+
+                // FIXME(eddyb) maybe extract this part into an `Iterator` impl? but it
+                // would be hard to return an interable that doesn't allocate nor borrow
+                // the iterator (whereas here `durations_across_profiles` borrows
+                // `self.sample_intervals_per_profile`)
+                let mut durations_across_profiles = std::iter::once(first_duration).chain(
+                    self.sample_intervals_per_profile[1..].iter_mut().map(|it| {
+                        let interval = it
+                            .next_back()
+                            .expect("`summarize aggregate` requires identical sequences of events");
+
+                        let duration = interval.duration();
+
+                        // Ensure we don't allow profiles that differ in event details.
+                        // FIXME(eddyb) this may be expensive (and is redundant
+                        // for every event, shared by adjacent intervals), there
+                        // should be a cheaper way to compare strings across
+                        // string tables, or even enforce that the string tables
+                        // of each profile are themselves identical.
+                        assert_eq!(
+                            descriptions,
+                            interval.map_event(WithParent::<EventDescription>::from),
+                            "`summarize aggregate` requires identical sequences of events"
+                        );
+
+                        duration
+                    }),
+                );
+
+                let (mut min_duration, mut max_duration) = {
+                    let first = durations_across_profiles.next().unwrap();
+                    (first, first)
+                };
+                for duration in durations_across_profiles {
+                    min_duration = min_duration.min(duration);
+                    max_duration = max_duration.max(duration);
+                }
+
+                Some(AggregatedSampleInterval {
+                    descriptions,
+
+                    min_duration,
+                    duration_variance: Variance {
+                        range_size: max_duration - min_duration,
+                    },
+                })
+            }
+            None => {
+                for leftover_intervals in self.sample_intervals_per_profile.iter_mut() {
+                    assert_eq!(
+                        leftover_intervals.next_back(),
+                        None,
+                        "`summarize aggregate` requires identical sequences of events"
+                    );
+                }
+                None
+            }
+        }
+    }
+}
+
+// FIXME(eddyb) move this somewhere else
+// (counterpoint: tracking "sources" of values is too specific)
+pub struct Extrema<T, S = ()> {
+    /// Number of `smallest`/`largest` values to keep track of.
+    limit: usize,
+
+    pub smallest: BTreeMap<T, ExtremaSources<S>>,
+    pub largest: BTreeMap<T, ExtremaSources<S>>,
+}
+
+pub enum ExtremaSources<S> {
+    Empty,
+    One(S),
+    Count(usize),
+}
+
+impl<S> Default for ExtremaSources<S> {
+    fn default() -> Self {
+        ExtremaSources::Empty
+    }
+}
+
+impl<S: Clone> ExtremaSources<S> {
+    pub fn count(&self) -> usize {
+        match *self {
+            ExtremaSources::Empty => 0,
+            ExtremaSources::One(_) => 1,
+            ExtremaSources::Count(count) => count,
+        }
+    }
+
+    pub fn add(&mut self, source: &S) {
+        *self = match self {
+            ExtremaSources::Empty => ExtremaSources::One(source.clone()),
+            _ => ExtremaSources::Count(self.count() + 1),
+        };
+    }
+}
+
+impl<T: Copy + Ord, S: Clone> Extrema<T, S> {
+    pub fn new(limit: usize) -> Self {
+        Extrema {
+            limit,
+
+            smallest: BTreeMap::new(),
+            largest: BTreeMap::new(),
+        }
+    }
+
+    pub fn add(&mut self, value: T, source: &S) {
+        self.add_range(value..=value, source)
+    }
+
+    pub fn add_range(&mut self, range: std::ops::RangeInclusive<T>, source: &S) {
+        enum Which {
+            Smallest,
+            Largest,
+        }
+
+        for which in &[Which::Smallest, Which::Largest] {
+            let (map, &value) = match which {
+                Which::Smallest => (&mut self.smallest, range.start()),
+                Which::Largest => (&mut self.largest, range.end()),
+            };
+            if map.len() < self.limit {
+                map.entry(value).or_default().add(source);
+            } else {
+                let least_extreme = match which {
+                    Which::Smallest => map.keys().rev().next().copied().unwrap(), // `max(smallest)`
+                    Which::Largest => map.keys().next().copied().unwrap(),        // `min(largest)`
+                };
+                let less_extreme = match which {
+                    Which::Smallest => value > least_extreme, // `value > max(smallest)`
+                    Which::Largest => value < least_extreme,  // `value < min(largest)`
+                };
+                if !less_extreme {
+                    map.entry(value).or_default().add(source);
+
+                    if map.len() > self.limit {
+                        map.remove(&least_extreme);
+                    }
+
+                    assert_eq!(map.len(), self.limit);
+                }
+            }
+        }
+    }
+}
+
+pub fn aggregate_profiles(profiles: Vec<ProfilingData>) {
+    let aggregated_sample_intervals = AggregatedSampleIntervals::new(
+        profiles
+            .iter()
+            .map(|data| SamplePoints::new(data.iter().map(|event| event.to_event())).intervals()),
+    );
+
+    let mut intervals_count = 0;
+
+    // FIXME(eddyb) make the `10` configurable at runtime (i.e. with a flag)
+    let mut durations = Extrema::new(10);
+    let mut variances = Extrema::new(10);
+
+    for interval in aggregated_sample_intervals.rev() {
+        intervals_count += 1;
+
+        durations.add_range(
+            interval.min_duration..=interval.max_duration(),
+            &interval.descriptions,
+        );
+        variances.add(interval.duration_variance, &interval.descriptions);
+    }
+
+    let describe =
+        |descriptions: ExtremaSources<SampleInterval<WithParent<EventDescription<'_>>>>| {
+            if let ExtremaSources::One(description) = descriptions {
+                match (description.start, description.end) {
+                    (SamplePoint::Start(start), SamplePoint::End(end)) => {
+                        assert_eq!(start, end);
+                        start.this.to_string()
+                    }
+
+                    (SamplePoint::Start(outer), SamplePoint::Start(inner))
+                    | (SamplePoint::Start(outer), SamplePoint::Instant(inner)) => {
+                        assert_eq!(inner.parent.as_ref(), Some(&outer.this));
+                        format!("in {}, before {}", outer.this, inner.this)
+                    }
+
+                    (SamplePoint::End(inner), SamplePoint::End(outer))
+                    | (SamplePoint::Instant(inner), SamplePoint::End(outer)) => {
+                        assert_eq!(inner.parent.as_ref(), Some(&outer.this));
+                        format!("in {}, after {}", outer.this, inner.this)
+                    }
+
+                    (SamplePoint::End(first), SamplePoint::Start(second))
+                    | (SamplePoint::Instant(first), SamplePoint::Start(second))
+                    | (SamplePoint::End(first), SamplePoint::Instant(second))
+                    | (SamplePoint::Instant(first), SamplePoint::Instant(second)) => {
+                        assert_eq!(first.parent, second.parent);
+                        if let Some(parent) = &first.parent {
+                            format!(
+                                "in {},\n    between {}\n        and {}\n",
+                                parent, first.this, second.this
+                            )
+                        } else {
+                            format!("between {} and {}", first.this, second.this)
+                        }
+                    }
+                }
+            } else {
+                let count = descriptions.count();
+                format!(
+                    "{} occurrences, or {:.2}%",
+                    count,
+                    (count as f64) / (intervals_count as f64) * 100.0
+                )
+            }
+        };
+
+    println!("Smallest {} durations:", durations.smallest.len());
+    for (duration, descriptions) in durations.smallest {
+        println!("  {} ns: {}", duration.as_nanos(), describe(descriptions));
+    }
+    println!("");
+    println!("Largest {} durations:", durations.largest.len());
+    for (duration, descriptions) in durations.largest {
+        println!("  {} ns: {}", duration.as_nanos(), describe(descriptions));
+    }
+    println!("");
+    println!("Smallest {} variances:", variances.smallest.len());
+    for (variance, descriptions) in variances.smallest {
+        println!(
+            "  ±{} ns: {}",
+            variance.range_size.as_nanos() as f64 / 2.0,
+            describe(descriptions)
+        );
+    }
+    println!("");
+    println!("Largest {} variances:", variances.largest.len());
+    for (variance, descriptions) in variances.largest {
+        println!(
+            "  ±{} ns: {}",
+            variance.range_size.as_nanos() as f64 / 2.0,
+            describe(descriptions)
+        );
+    }
+}


### PR DESCRIPTION
For my ongoing `rdpmc` instruction-counting work I've ended up with *a lot* of profile results (over 700 and there were hundreds I've already removed), that I don't really have any tools to analyze in-depth.

The fundamental problem is that e.g. `summarize summarize` will effectively sum together many small intervals between consecutive timestamps/instruction counts, so the distribution of variance in individual samples (of the clock/instruction counter), or the exact sources of large variances, are lost in the summary.

This PR seeks to address that by introducing a `summarize aggregate` command specifically for sets of deterministic runs (identical in all respects *except* the timestamps themselves). Example output:
```
$ summarize aggregate core-{48481,48701,48905,49453,49648,49860,50178,50587,50783,50978}
Smallest 10 durations:
  80 ns: 81 occurrences, or 0.00%
  90 ns: 10018 occurrences, or 0.59%
  91 ns: `hir_owner()`
  100 ns: 38546 occurrences, or 2.26%
  101 ns: 9 occurrences, or 0.00%
  110 ns: 49097 occurrences, or 2.87%
  111 ns: 14 occurrences, or 0.00%
  120 ns: 42200 occurrences, or 2.47%
  121 ns: 22 occurrences, or 0.00%
  130 ns: 52373 occurrences, or 3.07%

Largest 10 durations:
  111073277 ns: in `typeck()`,
    between `parent_module_from_def_id()`
        and `upvars_mentioned()`

  112291280 ns: `free_global_ctxt()`
  117943976 ns: in `typeck()`,
    between `parent_module_from_def_id()`
        and `upvars_mentioned()`

  126222248 ns: in `typeck()`,
    between `opt_const_param_of()`
        and `upvars_mentioned()`

  208308909 ns: in `typeck()`,
    between `parent_module_from_def_id()`
        and `upvars_mentioned()`

  220730751 ns: `build_hir_map()`
  221392949 ns: in `typeck()`,
    between `parent_module_from_def_id()`
        and `upvars_mentioned()`

  375357799 ns: `hir_lowering()`
  858511163 ns: `resolve_crate()`
  1139917634 ns: in `expand_crate()`, after `pre_AST_expansion_lint_checks()`

Smallest 10 variances:
  ±0 ns: 6057 occurrences, or 0.35%
  ±0.5 ns: 79 occurrences, or 0.00%
  ±4.5 ns: 8 occurrences, or 0.00%
  ±5 ns: 107368 occurrences, or 6.28%
  ±5.5 ns: 775 occurrences, or 0.05%
  ±9.5 ns: 55 occurrences, or 0.00%
  ±10 ns: 112015 occurrences, or 6.56%
  ±10.5 ns: 390 occurrences, or 0.02%
  ±14.5 ns: 42 occurrences, or 0.00%
  ±15 ns: 58164 occurrences, or 3.40%

Largest 10 variances:
  ±6107910 ns: `get_lib_features()`
  ±6942093.5 ns: `hir_lowering()`
  ±8277596.5 ns: in `privacy_access_levels()`,
    between `module_exports()`
        and `def_kind()`

  ±8340332.5 ns: in `typeck()`,
    between `parent_module_from_def_id()`
        and `upvars_mentioned()`

  ±8977432 ns: `resolve_crate()`
  ±9465039 ns: in `typeck()`,
    between `parent_module_from_def_id()`
        and `upvars_mentioned()`

  ±9681275.5 ns: in `privacy_access_levels()`, after `module_exports()`
  ±9737941 ns: in `death_checking()`,
    between `codegen_fn_attrs()`
        and `inherent_impls()`

  ±10313490.5 ns: in `expand_crate()`, after `pre_AST_expansion_lint_checks()`
  ±14306281.5 ns: `free_global_ctxt()`
```
For comparison, this is my best set of runs so far, for instruction counting (with `rdpmc` measuring both `instructions:u` and hardware interrupts, to account for `iret` overcounting, and `cpuid` for serialization):
```
$ summarize aggregate core-{047003,047937,048427,048692,048991,049165,049351,049555,049743,050036} \
    | sed 's/ ns/ instructions/'
Smallest 10 durations:
  97 instructions: 3 occurrences, or 0.00%
  99 instructions: 2 occurrences, or 0.00%
  112 instructions: `llvm_dump_timing_file()`
  114 instructions: `dep_graph_tcx_init()`
  121 instructions: `link_binary_check_files_are_writeable()`
  123 instructions: `plugin_registration()`
  157 instructions: `serialize_work_products()`
  164 instructions: `attributes_injection()`
  166 instructions: `drop_dep_graph()`
  170 instructions: in `index_hir()`, after `build_hir_map()`

Largest 10 durations:
  289482983 instructions: `early_lint_checks()`
  421515729 instructions: in `typeck()`,
    between `parent_module_from_def_id()`
        and `upvars_mentioned()`

  426300619 instructions: in `typeck()`,
    between `parent_module_from_def_id()`
        and `upvars_mentioned()`

  434275596 instructions: in `typeck()`,
    between `opt_const_param_of()`
        and `upvars_mentioned()`

  754467760 instructions: in `typeck()`,
    between `parent_module_from_def_id()`
        and `upvars_mentioned()`

  769694431 instructions: in `typeck()`,
    between `parent_module_from_def_id()`
        and `upvars_mentioned()`

  1082435704 instructions: `hir_lowering()`
  1270692563 instructions: `build_hir_map()`
  3884803038 instructions: `resolve_crate()`
  4059854999 instructions: in `expand_crate()`, after `pre_AST_expansion_lint_checks()`

Smallest 10 variances:
  ±0 instructions: 1701795 occurrences, or 99.61%
  ±0.5 instructions: 519 occurrences, or 0.03%
  ±1 instructions: 11 occurrences, or 0.00%
  ±1.5 instructions: 61 occurrences, or 0.00%
  ±2 instructions: 290 occurrences, or 0.02%
  ±2.5 instructions: 108 occurrences, or 0.01%
  ±3 instructions: 6 occurrences, or 0.00%
  ±3.5 instructions: 124 occurrences, or 0.01%
  ±4 instructions: 68 occurrences, or 0.00%
  ±4.5 instructions: 71 occurrences, or 0.00%

Largest 10 variances:
  ±217.5 instructions: in `mir_borrowck()`,
    between `mir_validated()`
        and `is_late_bound_map()`

  ±236.5 instructions: in `mir_borrowck()`,
    between `is_late_bound_map()`
        and `type_op_prove_predicate()`

  ±263.5 instructions: in `mir_borrowck()`, after `is_late_bound_map()`
  ±267.5 instructions: in `mir_borrowck()`,
    between `mir_validated()`
        and `is_late_bound_map()`

  ±354.5 instructions: in `mir_borrowck()`, after `type_op_prove_predicate()`
  ±445 instructions: in `mir_borrowck()`, after `is_late_bound_map()`
  ±468.5 instructions: in `drop_ast()`, before `analysis()`
  ±649.5 instructions: `hir_lowering()`
  ±659 instructions: `free_global_ctxt()`
  ±1147 instructions: in `expand_crate()`, after `pre_AST_expansion_lint_checks()`
```

~~This is *not* the intended final output, just the simplest analysis I could do, that is still somewhat indicative of the quality of the data. To be truly useful in *improving* that quality, it has to be able to pinpoint to outliers, not just quantify their existence.~~

**EDIT**: added some very basic indications of sources of single occurrences (and updated the example output above)
**EDIT2**: streamlined the single-occurrence output and included the parent (or caller) of the two interval endpoints, when it's relevant (i.e. when the interval is part of it, between one call ending and the other starting, *not* either callee)