### PR TITLE
Hardware performance counter support (via `rdpmc`).

### DIFF
--- a/measureme/Cargo.toml
+++ b/measureme/Cargo.toml
@@ -13,6 +13,14 @@ repository = "https://github.com/rust-lang/measureme"
 travis-ci = { repository = "rust-lang/measureme" }
 
 [dependencies]
+log = "0.4"
 parking_lot = "0.11.0"
 rustc-hash = "1.0.1"
 smallvec = "1.0"
+
+[features]
+nightly = []
+
+[target.'cfg(all(target_arch = "x86_64", target_os = "linux"))'.dependencies]
+memmap = "0.7"
+perf-event-open-sys = "1.0.1"

--- a/measureme/src/counters.rs
+++ b/measureme/src/counters.rs
@@ -81,7 +81,7 @@
 //!     which can cause non-deterministic overcounting for instructions following
 //!     an atomic instruction (such as found in heap allocators, or `measureme`)
 //!     * this is automatically detected, with a `log` message pointing the user
-//!       to [https://github.com/mozilla/rr/wiki/Zen] for guidance on how to
+//!       to <https://github.com/mozilla/rr/wiki/Zen> for guidance on how to
 //!       disable `SpecLockMap` on their system (sadly requires root access)
 //!
 //! Even if some of the above caveats apply for some profiling setup, as long as

--- a/measureme/src/counters.rs
+++ b/measureme/src/counters.rs
@@ -1,0 +1,869 @@
+use std::error::Error;
+use std::time::Instant;
+
+// HACK(eddyb) this is semantically `warn!` but uses `error!` because
+// that's the only log level enabled by default - see also
+// https://github.com/rust-lang/rust/issues/76824
+macro_rules! really_warn {
+    ($msg:literal $($rest:tt)*) => {
+        error!(concat!("[WARNING] ", $msg) $($rest)*)
+    }
+}
+
+pub enum Counter {
+    WallTime(WallTime),
+    Instructions(Instructions),
+    InstructionsMinusIrqs(InstructionsMinusIrqs),
+    InstructionsMinusRaw0420(InstructionsMinusRaw0420),
+}
+
+impl Counter {
+    pub fn by_name(name: &str) -> Result<Self, Box<dyn Error + Send + Sync>> {
+        Ok(match name {
+            WallTime::NAME => Counter::WallTime(WallTime::new()),
+            Instructions::NAME => Counter::Instructions(Instructions::new()?),
+            InstructionsMinusIrqs::NAME => {
+                Counter::InstructionsMinusIrqs(InstructionsMinusIrqs::new()?)
+            }
+            InstructionsMinusRaw0420::NAME => {
+                Counter::InstructionsMinusRaw0420(InstructionsMinusRaw0420::new()?)
+            }
+            _ => return Err(format!("{:?} is not a valid counter name", name).into()),
+        })
+    }
+
+    pub(super) fn describe_as_json(&self) -> String {
+        let (name, units) = match self {
+            Counter::WallTime(_) => (
+                WallTime::NAME,
+                r#"[["ns", 1], ["μs", 1000], ["ms", 1000000], ["s", 1000000000]]"#,
+            ),
+            Counter::Instructions(_) => (Instructions::NAME, r#"[["instructions", 1]]"#),
+            Counter::InstructionsMinusIrqs(_) => {
+                (InstructionsMinusIrqs::NAME, r#"[["instructions", 1]]"#)
+            }
+            Counter::InstructionsMinusRaw0420(_) => {
+                (InstructionsMinusRaw0420::NAME, r#"[["instructions", 1]]"#)
+            }
+        };
+        format!(r#"{{ "name": "{}", "units": {} }}"#, name, units)
+    }
+
+    #[inline]
+    pub(super) fn since_start(&self) -> u64 {
+        match self {
+            Counter::WallTime(counter) => counter.since_start(),
+            Counter::Instructions(counter) => counter.since_start(),
+            Counter::InstructionsMinusIrqs(counter) => counter.since_start(),
+            Counter::InstructionsMinusRaw0420(counter) => counter.since_start(),
+        }
+    }
+}
+
+pub struct WallTime {
+    start: Instant,
+}
+
+impl WallTime {
+    const NAME: &'static str = "wall-time";
+
+    pub fn new() -> Self {
+        WallTime {
+            start: Instant::now(),
+        }
+    }
+
+    #[inline]
+    fn since_start(&self) -> u64 {
+        self.start.elapsed().as_nanos() as u64
+    }
+}
+
+pub struct Instructions {
+    instructions: hw::Counter,
+    start: u64,
+}
+
+impl Instructions {
+    const NAME: &'static str = "instructions:u";
+
+    pub fn new() -> Result<Self, Box<dyn Error + Send + Sync>> {
+        let model = hw::CpuModel::detect()?;
+        let instructions = hw::Counter::new(&model, HwCounterType::Instructions)?;
+        let start = instructions.read();
+        Ok(Instructions {
+            instructions,
+            start,
+        })
+    }
+
+    #[inline]
+    fn since_start(&self) -> u64 {
+        self.instructions.read().wrapping_sub(self.start)
+    }
+}
+
+pub struct InstructionsMinusIrqs {
+    instructions: hw::Counter,
+    irqs: hw::Counter,
+    start: u64,
+}
+
+impl InstructionsMinusIrqs {
+    const NAME: &'static str = "instructions-minus-irqs:u";
+
+    pub fn new() -> Result<Self, Box<dyn Error + Send + Sync>> {
+        let model = hw::CpuModel::detect()?;
+        let instructions = hw::Counter::new(&model, HwCounterType::Instructions)?;
+        let irqs = hw::Counter::new(&model, HwCounterType::Irqs)?;
+        let (start_instructions, start_irqs) = (&instructions, &irqs).read();
+        let start = start_instructions.wrapping_sub(start_irqs);
+        Ok(InstructionsMinusIrqs {
+            instructions,
+            irqs,
+            start,
+        })
+    }
+
+    #[inline]
+    fn since_start(&self) -> u64 {
+        let (instructions, irqs) = (&self.instructions, &self.irqs).read();
+        instructions.wrapping_sub(irqs).wrapping_sub(self.start)
+    }
+}
+
+// HACK(eddyb) this is a variant of `instructions-minus-irqs:u`, where `r0420`
+// is subtracted, instead of the usual "hardware interrupts" (aka IRQs).
+// `r0420` is an undocumented counter on AMD Zen CPUs which appears to count
+// both hardware interrupts and exceptions (such as page faults), though
+// it's unclear yet what exactly it's counting (could even be `iret`s).
+pub struct InstructionsMinusRaw0420(InstructionsMinusIrqs);
+
+impl InstructionsMinusRaw0420 {
+    const NAME: &'static str = "instructions-minus-r0420:u";
+
+    pub fn new() -> Result<Self, Box<dyn Error + Send + Sync>> {
+        let model = hw::CpuModel::detect()?;
+        let instructions = hw::Counter::new(&model, HwCounterType::Instructions)?;
+        let irqs = hw::Counter::new(&model, HwCounterType::Raw0420)?;
+        let (start_instructions, start_irqs) = (&instructions, &irqs).read();
+        let start = start_instructions.wrapping_sub(start_irqs);
+        Ok(InstructionsMinusRaw0420(InstructionsMinusIrqs {
+            instructions,
+            irqs,
+            start,
+        }))
+    }
+
+    #[inline]
+    fn since_start(&self) -> u64 {
+        self.0.since_start()
+    }
+}
+
+trait HwCounterRead {
+    type Output;
+    fn read(&self) -> Self::Output;
+}
+
+enum HwCounterType {
+    Instructions,
+    Irqs,
+    Raw0420,
+}
+
+const BUG_REPORT_MSG: &str =
+    "please report this to https://github.com/rust-lang/measureme/issues/new";
+
+/// Linux x86_64 implementation based on `perf_event_open` and `rdpmc`.
+#[cfg(all(feature = "nightly", target_arch = "x86_64", target_os = "linux"))]
+mod hw {
+    use memmap::{Mmap, MmapOptions};
+    use perf_event_open_sys::{bindings::*, perf_event_open};
+    use std::convert::TryInto;
+    use std::error::Error;
+    use std::fs;
+    use std::mem;
+    use std::os::unix::io::FromRawFd;
+
+    pub(super) struct Counter {
+        mmap: Mmap,
+        reg_idx: u32,
+    }
+
+    impl Counter {
+        pub(super) fn new(
+            model: &CpuModel,
+            counter_type: super::HwCounterType,
+        ) -> Result<Self, Box<dyn Error + Send + Sync>> {
+            let (type_, hw_id) = match counter_type {
+                super::HwCounterType::Instructions => (
+                    perf_type_id_PERF_TYPE_HARDWARE,
+                    perf_hw_id_PERF_COUNT_HW_INSTRUCTIONS,
+                ),
+                super::HwCounterType::Irqs => {
+                    (perf_type_id_PERF_TYPE_RAW, model.irqs_counter_config()?)
+                }
+                super::HwCounterType::Raw0420 => {
+                    match model {
+                        CpuModel::Amd(AmdGen::Zen) => {}
+
+                        _ => really_warn!(
+                            "Counter::new: the undocumented `r0420` performance \
+                             counter has only been observed on AMD Zen CPUs"
+                        ),
+                    }
+
+                    (perf_type_id_PERF_TYPE_RAW, 0x04_20)
+                }
+            };
+            Self::with_type_and_hw_id(type_, hw_id)
+        }
+
+        fn with_type_and_hw_id(
+            type_: perf_type_id,
+            hw_id: u32,
+        ) -> Result<Self, Box<dyn Error + Send + Sync>> {
+            let mut attrs = perf_event_attr {
+                size: mem::size_of::<perf_event_attr>().try_into().unwrap(),
+                type_,
+                config: hw_id.into(),
+                ..perf_event_attr::default()
+            };
+
+            // Only record same-thread, any CPUs, and only userspace (no kernel/hypervisor).
+            // NOTE(eddyb) `pid = 0`, despite talking about "process id", means
+            // "calling process/thread", *not* "any thread in the calling process"
+            // (i.e. "process" is interchangeable with "main thread of the process")
+            // FIXME(eddyb) introduce per-thread counters and/or use `inherit`
+            // (and `inherit_stat`? though they might not be appropriate here)
+            // to be able to read the counter on more than just the initial thread.
+            let pid = 0;
+            let cpu = -1;
+            let group_fd = -1;
+            attrs.set_exclude_kernel(1);
+            attrs.set_exclude_hv(1);
+
+            let file = unsafe {
+                let fd =
+                    perf_event_open(&mut attrs, pid, cpu, group_fd, PERF_FLAG_FD_CLOEXEC.into());
+                if fd < 0 {
+                    Err(std::io::Error::from_raw_os_error(-fd))
+                } else {
+                    Ok(fs::File::from_raw_fd(fd))
+                }
+            };
+            let file = file.map_err(|e| format!("perf_event_open failed: {:?}", e))?;
+
+            let mmap = unsafe {
+                MmapOptions::new()
+                    .len(mem::size_of::<perf_event_mmap_page>())
+                    .map(&file)
+            };
+            let mmap = mmap.map_err(|e| format!("perf_event_mmap_page: mmap failed: {:?}", e))?;
+
+            let mut counter = Counter { mmap, reg_idx: 0 };
+
+            let (version, compat_version, caps, index, pmc_width) = counter
+                .access_mmap_page_with_seqlock(|mp| {
+                    (
+                        mp.version,
+                        mp.compat_version,
+                        unsafe { mp.__bindgen_anon_1.__bindgen_anon_1 },
+                        mp.index,
+                        mp.pmc_width,
+                    )
+                });
+
+            info!(
+                "Counter::new: version={} compat_version={} index={:#x}",
+                version, compat_version, index,
+            );
+
+            if caps.cap_user_rdpmc() == 0 {
+                return Err(format!(
+                    "perf_event_mmap_page: missing cap_user_rdpmc{}",
+                    if caps.cap_bit0_is_deprecated() == 0 && caps.cap_bit0() == 1 {
+                        " (ignoring legacy/broken rdpmc support)"
+                    } else {
+                        ""
+                    }
+                )
+                .into());
+            }
+
+            if index == 0 {
+                return Err(format!(
+                    "perf_event_mmap_page: no allocated hardware register (ran out?)"
+                )
+                .into());
+            }
+            counter.reg_idx = index - 1;
+
+            if (cfg!(not(accurate_seqlock_rdpmc)) || true) && pmc_width != 48 {
+                return Err(format!(
+                    "perf_event_mmap_page: {}-bit hardware counter found, only 48-bit supported",
+                    pmc_width
+                )
+                .into());
+            }
+
+            Ok(counter)
+        }
+
+        /// Try to access the mmap page, retrying the `attempt` closure as long
+        /// as the "seqlock" sequence number changes (which indicates the kernel
+        /// has updated one or more fields within the mmap page).
+        #[inline]
+        fn access_mmap_page_with_seqlock<T>(
+            &self,
+            attempt: impl Fn(&perf_event_mmap_page) -> T,
+        ) -> T {
+            // FIXME(eddyb) it's probably UB to use regular reads, especially
+            // from behind `&T`, with the only synchronization being barriers.
+            // Probably needs atomic reads, and stronger ones at that, for the
+            // `lock` field, than the fields (which would be `Relaxed`?).
+            let mmap_page = unsafe { &*(self.mmap.as_ptr() as *const perf_event_mmap_page) };
+            let barrier = || std::sync::atomic::fence(std::sync::atomic::Ordering::Acquire);
+
+            loop {
+                // Grab the "seqlock" - the kernel will update this value when it
+                // updates any of the other fields that may be read in `attempt`.
+                let seq_lock = mmap_page.lock;
+                barrier();
+
+                let result = attempt(mmap_page);
+
+                // If nothing has changed, we're done. Otherwise, keep retrying.
+                barrier();
+                if mmap_page.lock == seq_lock {
+                    return result;
+                }
+            }
+        }
+    }
+
+    impl super::HwCounterRead for Counter {
+        type Output = u64;
+
+        #[inline]
+        fn read(&self) -> u64 {
+            // HACK(eddyb) keep the accurate code around while not using it,
+            // to minimize overhead without losing the more complex implementation.
+            let (counter, offset, pmc_width) = if cfg!(accurate_seqlock_rdpmc) && false {
+                self.access_mmap_page_with_seqlock(|mp| {
+                    let caps = unsafe { mp.__bindgen_anon_1.__bindgen_anon_1 };
+                    assert_ne!(caps.cap_user_rdpmc(), 0);
+
+                    (
+                        rdpmc(mp.index.checked_sub(1).unwrap()),
+                        mp.offset,
+                        mp.pmc_width,
+                    )
+                })
+            } else {
+                (rdpmc(self.reg_idx), 0, 48)
+            };
+
+            let counter = offset + (counter as i64);
+
+            // Sign-extend the `pmc_width`-bit value to `i64`.
+            (counter << (64 - pmc_width) >> (64 - pmc_width)) as u64
+        }
+    }
+
+    impl super::HwCounterRead for (&Counter, &Counter) {
+        type Output = (u64, u64);
+
+        #[inline]
+        fn read(&self) -> (u64, u64) {
+            // HACK(eddyb) keep the accurate code around while not using it,
+            // to minimize overhead without losing the more complex implementation.
+            if (cfg!(accurate_seqlock_rdpmc) || cfg!(unserialized_rdpmc)) && false {
+                return (self.0.read(), self.1.read());
+            }
+
+            let pmc_width = 48;
+
+            let (a_counter, b_counter) = rdpmc_pair(self.0.reg_idx, self.1.reg_idx);
+
+            // Sign-extend the `pmc_width`-bit values to `i64`.
+            (
+                ((a_counter as i64) << (64 - pmc_width) >> (64 - pmc_width)) as u64,
+                ((b_counter as i64) << (64 - pmc_width) >> (64 - pmc_width)) as u64,
+            )
+        }
+    }
+
+    /// Read the hardware performance counter indicated by `reg_idx`.
+    ///
+    /// If the counter is signed, sign extension should be performed based on
+    /// the width of the register (32 to 64 bits, e.g. 48-bit seems common).
+    #[inline(always)]
+    fn rdpmc(reg_idx: u32) -> u64 {
+        let (lo, hi): (u32, u32);
+        unsafe {
+            // NOTE(eddyb) below comment is outdated (the other branch uses `cpuid`).
+            if cfg!(unserialized_rdpmc) && false {
+                // FIXME(eddyb) the Intel and AMD manuals warn about the need for
+                // "serializing instructions" before/after `rdpmc`, if avoiding any
+                // reordering is desired, but do not agree on the full set of usable
+                // "serializing instructions" (e.g. `mfence` isn't listed in both).
+                //
+                // The only usable, and guaranteed to work, "serializing instruction"
+                // appears to be `cpuid`, but it doesn't seem easy to use, especially
+                // due to the overlap in registers with `rdpmc` itself, and it might
+                // have too high of a cost, compared to serialization benefits (if any).
+                asm!("rdpmc", in("ecx") reg_idx, out("eax") lo, out("edx") hi, options(nostack));
+            } else {
+                asm!(
+                    // Dummy `cpuid(0)` to serialize instruction execution.
+                    "xor eax, eax",
+                    "cpuid",
+
+                    "mov ecx, {rdpmc_ecx:e}",
+                    "rdpmc",
+                    rdpmc_ecx = in(reg) reg_idx,
+                    out("eax") lo,
+                    out("edx") hi,
+
+                    // `cpuid` clobbers (not overwritten by `rdpmc`).
+                    out("ebx") _,
+                    out("ecx") _,
+
+                    options(nostack),
+                );
+            }
+        }
+        lo as u64 | (hi as u64) << 32
+    }
+
+    /// Read two hardware performance counters at once (see `rdpmc`).
+    ///
+    /// Should be more efficient/accurate than two `rdpmc` calls, as it
+    /// only requires one "serializing instruction", rather than two.
+    #[inline(always)]
+    fn rdpmc_pair(a_reg_idx: u32, b_reg_idx: u32) -> (u64, u64) {
+        let (a_lo, a_hi): (u32, u32);
+        let (b_lo, b_hi): (u32, u32);
+        unsafe {
+            asm!(
+                // Dummy `cpuid(0)` to serialize instruction execution.
+                "xor eax, eax",
+                "cpuid",
+
+                "mov ecx, {a_rdpmc_ecx:e}",
+                "rdpmc",
+                "mov {a_rdpmc_eax:e}, eax",
+                "mov {a_rdpmc_edx:e}, edx",
+                "mov ecx, {b_rdpmc_ecx:e}",
+                "rdpmc",
+                a_rdpmc_ecx = in(reg) a_reg_idx,
+                a_rdpmc_eax = out(reg) a_lo,
+                a_rdpmc_edx = out(reg) a_hi,
+                b_rdpmc_ecx = in(reg) b_reg_idx,
+                out("eax") b_lo,
+                out("edx") b_hi,
+
+                // `cpuid` clobbers (not overwritten by `rdpmc`).
+                out("ebx") _,
+                out("ecx") _,
+
+                options(nostack),
+            );
+        }
+        (
+            a_lo as u64 | (a_hi as u64) << 32,
+            b_lo as u64 | (b_hi as u64) << 32,
+        )
+    }
+
+    /// Categorization of `x86_64` CPUs, primarily based on how they
+    /// support for counting "hardware interrupts" (documented or not).
+    pub(super) enum CpuModel {
+        Amd(AmdGen),
+        Intel(IntelGen),
+    }
+
+    pub(super) enum AmdGen {
+        /// K8 (Hammer) to Jaguar / Puma.
+        PreZen,
+
+        /// Zen / Zen+ / Zen 2.
+        Zen,
+
+        /// Unknown AMD CPU, contemporary to/succeeding Zen/Zen+/Zen 2,
+        /// but likely similar to them.
+        UnknownMaybeZenLike,
+    }
+
+    pub(super) enum IntelGen {
+        /// Intel CPU predating Sandy Bridge. These are the only CPUs we
+        /// can't support (more) accurate instruction counting on, as they
+        /// don't (appear to) have any way to count "hardware interrupts".
+        PreBridge,
+
+        /// Sandy Bridge / Ivy Bridge:
+        /// * client: Sandy Bridge (M/H) / Ivy Bridge (M/H/Gladden)
+        /// * server: Sandy Bridge (E/EN/EP) / Ivy Bridge (E/EN/EP/EX)
+        ///
+        /// Intel doesn't document support for counting "hardware interrupts"
+        /// prior to Skylake, but testing found that `HW_INTERRUPTS.RECEIVED`
+        /// from Skylake has existed, with the same config, as far back as
+        /// "Sandy Bridge" (but before that it mapped to a different event).
+        ///
+        /// These are the (pre-Skylake) *Bridge CPU models confirmed so far:
+        /// * Sandy Bridge (client) Family 6 Model 42
+        ///     Intel(R) Core(TM) i5-2520M CPU @ 2.50GHz (@alyssais)
+        /// * Ivy Bridge (client) Family 6 Model 58
+        ///     Intel(R) Core(TM) i7-3520M CPU @ 2.90GHz (@eddyb)
+        ///
+        /// We later found this paper, which on page 5 lists 12 counters,
+        /// for each of Nehalem/Westmere, Sandy Bridge and Ivy Bridge:
+        /// http://web.eece.maine.edu/~vweaver/projects/deterministic/deterministic_counters.pdf
+        /// It appears that both Sandy Bridge and Ivy Bridge used to have
+        /// `HW_INTERRUPTS.RECEIVED` documented, before Intel removed every
+        /// mention of the counter from newer versions of their manuals.
+        Bridge,
+
+        /// Haswell / Broadwell:
+        /// * client: Haswell (S/ULT/GT3e) / Broadwell (U/Y/S/H/C/W)
+        /// * server: Haswell (E/EP/EX) / Broadwell (E/EP/EX/DE/Hewitt Lake)
+        ///
+        /// Equally as undocumented as "Sandy Bridge / Ivy Bridge" (see above).
+        ///
+        /// These are the (pre-Skylake) *Well CPU models confirmed so far:
+        /// * Haswell (client) Family 6 Model 60
+        ///     Intel(R) Core(TM) i7-4790K CPU @ 4.00GHz (@m-ou-se)
+        /// * Haswell (server) Family 6 Model 63
+        ///     Intel(R) Xeon(R) CPU E5-2697 v3 @ 2.60GHz (@cuviper)
+        /// * Haswell (client + GT3e) Family 6 Model 70
+        ///     Intel(R) Core(TM) i7-4750HQ CPU @ 2.00GHz (@nagisa)
+        ///     Intel(R) Core(TM) i7-4770HQ CPU @ 2.20GHz (@m-ou-se)
+        Well,
+
+        /// Skylake / Skylake-derived:
+        /// * client: Skylake (Y/U/DT/H/S) / Kaby Lake (Y/U/DT/H/S/X) / Coffee Lake (U/S/H/E)
+        /// * server: Skylake (SP/X/DE/W) / Cascade Lake (SP/X/W)
+        ///
+        /// Both "client" and "server" product lines have documented support
+        /// for counting "hardware interrupts" (`HW_INTERRUPTS.RECEIVED`).
+        ///
+        /// Intel does not make it clear that future product lines, such as
+        /// "Ice Lake", will continue to support this (or with what config),
+        /// and even "Comet Lake" (aka "10th gen") isn't explicitly listed.
+        Lake,
+
+        /// Unknown Intel CPU, contemporary to/succeeding *Bridge/*Well/*Lake,
+        /// but likely similar to them.
+        UnknownMaybeLakeLike,
+    }
+
+    impl CpuModel {
+        /// Detect the model of the current CPU using `cpuid`.
+        pub(super) fn detect() -> Result<Self, Box<dyn Error + Send + Sync>> {
+            let cpuid0 = unsafe { std::arch::x86_64::__cpuid(0) };
+            let cpuid1 = unsafe { std::arch::x86_64::__cpuid(1) };
+            let mut vendor = [0; 12];
+            vendor[0..4].copy_from_slice(&cpuid0.ebx.to_le_bytes());
+            vendor[4..8].copy_from_slice(&cpuid0.edx.to_le_bytes());
+            vendor[8..12].copy_from_slice(&cpuid0.ecx.to_le_bytes());
+
+            let vendor = std::str::from_utf8(&vendor).map_err(|_| {
+                format!(
+                    "cpuid returned non-UTF-8 vendor name: cpuid(0)={:?} cpuid(1)={:?}",
+                    cpuid0, cpuid1
+                )
+            })?;
+
+            let version = cpuid1.eax;
+
+            let mut family = (version >> 8) & 0xf;
+            if family == 15 {
+                // Extended family.
+                family += (version >> 20) & 0xff;
+            }
+
+            let mut model = (version >> 4) & 0xf;
+            if family >= 15 || vendor == "GenuineIntel" && family == 6 {
+                // Extended model.
+                model += ((version >> 16) & 0xf) << 4;
+            }
+
+            info!(
+                "CpuModel::detect: vendor={:?} family={} model={}",
+                vendor, family, model
+            );
+
+            match vendor {
+                "AuthenticAMD" => {
+                    use self::AmdGen::*;
+
+                    let (gen, name) = match (family, model) {
+                        (0..=14, _) | (19, _) => {
+                            return Err(format!(
+                                "impossible AMD64 CPU detected (Family {} Model {}); {}",
+                                family,
+                                model,
+                                super::BUG_REPORT_MSG
+                            )
+                            .into());
+                        }
+
+                        (15, _) => (PreZen, "K8 (Hammer)"),
+                        (16, _) => (PreZen, "K10 (Barcelona/Shanghai/Istanbul)"),
+                        (17, _) => (PreZen, "K8+K10 hybrid (Turion X2 Ultra)"),
+                        (18, _) => (PreZen, "Fusion"),
+                        (20, _) => (PreZen, "Bobcat"),
+                        (21, _) => (PreZen, "Bulldozer / Piledriver / Steamroller / Excavator"),
+                        (22, _) => (PreZen, "Jaguar / Puma"),
+
+                        (23, 1) => (Zen, "Zen (Naples/Whitehaven/Summit Ridge/Snowy Owl)"),
+                        (23, 17) => (Zen, "Zen (Raven Ridge)"),
+                        (23, 24) => (Zen, "Zen (Banded Kestrel/Dali) / Zen+ (Picasso)"),
+                        (23, 8) => (Zen, "Zen+ (Pinnacle Ridge)"),
+                        (23, 49) => (Zen, "Zen 2 (Rome/Castle Peak)"),
+                        (23, 113) => (Zen, "Zen 2 (Matisse)"),
+
+                        (23..=0xffff_ffff, _) => {
+                            really_warn!(
+                                "CpuModel::detect: unknown AMD CPU (Family {} Model {}), \
+                                 assuming Zen-like; {}",
+                                family,
+                                model,
+                                super::BUG_REPORT_MSG
+                            );
+
+                            (UnknownMaybeZenLike, "")
+                        }
+                    };
+
+                    if !name.is_empty() {
+                        info!("CpuModel::detect: known AMD CPU: {}", name);
+                    }
+
+                    // The `SpecLockMap` (speculative atomic aka `lock` instruction
+                    // execution, unclear what "Map" refers to) feature in AMD Zen CPUs
+                    // causes non-deterministic overcounting of atomic instructions,
+                    // presumably whenever it has to roll back the speculation
+                    // (as in, the performance counters aren't rolled back).
+                    // Even this this may be rare when uncontended, it adds up.
+                    //
+                    // There is an MSR bit (`MSRC001_1020[54]`) that's not officially
+                    // documented, but which several motherboards and profiling tools
+                    // set whenever IBS (Instruction-Based Sampling) is in use, and
+                    // it is sometimes referred to as "disabling `SpecLockMap`"
+                    // (hence having a name for the feature that speculates `lock`s).
+                    //
+                    // One way we could detect that the bit has been set would be to
+                    // parse `uname().release` (aka `uname -r`) and look for versions
+                    // which are known to include the patch suggested in this thread:
+                    // https://github.com/mozilla/rr/issues/2034#issuecomment-693761247
+                    //
+                    // However, one may set the bit using e.g. `wrmsr`, even on older
+                    // kernels, so a more reliable approach is to execute some atomics
+                    // and look at the `SpecLockMapCommit` (`r0825:u`) Zen counter,
+                    // which only reliably remains `0` when `SpecLockMap` is disabled.
+                    if matches!(gen, Zen | UnknownMaybeZenLike) {
+                        if let Ok(spec_lock_map_commit) =
+                            Counter::with_type_and_hw_id(perf_type_id_PERF_TYPE_RAW, 0x08_25)
+                        {
+                            use super::HwCounterRead;
+
+                            let start_spec_lock_map_commit = spec_lock_map_commit.read();
+
+                            // Execute an atomic (`lock`) instruction, which should
+                            // start speculative execution for following instructions
+                            // (as long as `SpecLockMap` isn't disabled).
+                            let mut atomic: u64 = 0;
+                            let mut _tmp: u64 = 0;
+                            unsafe {
+                                asm!(
+                                    "lock xadd qword ptr [{atomic}], {tmp}",
+
+                                    atomic = in(reg) &mut atomic,
+                                    tmp = inout(reg) _tmp,
+                                );
+                            }
+
+                            if spec_lock_map_commit.read() != start_spec_lock_map_commit {
+                                really_warn!(
+                                    "CpuModel::detect: SpecLockMap detected, in AMD {} CPU; \
+                                     this may add some non-deterministic noise - \
+                                     for information on disabling SpecLockMap, see \
+                                     https://github.com/mozilla/rr/wiki/Zen",
+                                    name
+                                );
+                            }
+                        }
+                    }
+
+                    Ok(CpuModel::Amd(gen))
+                }
+
+                "GenuineIntel" => {
+                    use self::IntelGen::*;
+
+                    let (gen, name) = match (family, model) {
+                        // No need to name these, they're unsupported anyway.
+                        (0..=5, _) => (PreBridge, ""),
+                        (15, _) => (PreBridge, "Netburst"),
+                        (6, 0..=41) => (PreBridge, ""),
+
+                        // Older Xeon Phi CPUs, misplaced in Family 6.
+                        (6, 87) => (PreBridge, "Knights Landing"),
+                        (6, 133) => (PreBridge, "Knights Mill"),
+
+                        // Older Atom CPUs, interleaved with other CPUs.
+                        // FIXME(eddyb) figure out if these are like *Bridge/*Well.
+                        (6, 53) | (6, 54) => (PreBridge, "Saltwell"),
+                        (6, 55) | (6, 74) | (6, 77) | (6, 90) | (6, 93) => {
+                            (PreBridge, "Silvermont")
+                        }
+                        (6, 76) => (PreBridge, "Airmont (Cherry Trail/Braswell)"),
+
+                        // Older server CPUs, numbered out of order.
+                        (6, 44) => (PreBridge, "Westmere (Gulftown/EP)"),
+                        (6, 46) => (PreBridge, "Nehalem (EX)"),
+                        (6, 47) => (PreBridge, "Westmere (EX)"),
+
+                        (6, 42) => (Bridge, "Sandy Bridge (M/H)"),
+                        (6, 45) => (Bridge, "Sandy Bridge (E/EN/EP)"),
+                        (6, 58) => (Bridge, "Ivy Bridge (M/H/Gladden)"),
+                        (6, 62) => (Bridge, "Ivy Bridge (E/EN/EP/EX)"),
+
+                        (6, 60) => (Well, "Haswell (S)"),
+                        (6, 61) => (Well, "Broadwell (U/Y/S)"),
+                        (6, 63) => (Well, "Haswell (E/EP/EX)"),
+                        (6, 69) => (Well, "Haswell (ULT)"),
+                        (6, 70) => (Well, "Haswell (GT3e)"),
+                        (6, 71) => (Well, "Broadwell (H/C/W)"),
+                        (6, 79) => (Well, "Broadwell (E/EP/EX)"),
+                        (6, 86) => (Well, "Broadwell (DE/Hewitt Lake)"),
+
+                        (6, 78) => (Lake, "Skylake (Y/U)"),
+                        (6, 85) => (Lake, "Skylake (SP/X/DE/W) / Cascade Lake (SP/X/W)"),
+                        (6, 94) => (Lake, "Skylake (DT/H/S)"),
+                        (6, 142) => (Lake, "Kaby Lake (Y/U) / Coffee Lake (U)"),
+                        (6, 158) => (Lake, "Kaby Lake (DT/H/S/X) / Coffee Lake (S/H/E)"),
+
+                        (6..=14, _) | (16..=0xffff_ffff, _) => {
+                            really_warn!(
+                                "CpuModel::detect: unknown Intel CPU (Family {} Model {}), \
+                                 assuming Skylake-like; {}",
+                                family,
+                                model,
+                                super::BUG_REPORT_MSG
+                            );
+
+                            (UnknownMaybeLakeLike, "")
+                        }
+                    };
+
+                    if !name.is_empty() {
+                        info!("CpuModel::detect: known Intel CPU: {}", name);
+                    }
+
+                    Ok(CpuModel::Intel(gen))
+                }
+
+                _ => Err(format!(
+                    "cpuid returned unknown CPU vendor {:?}; version={:#x}",
+                    vendor, version
+                )
+                .into()),
+            }
+        }
+
+        /// Return the hardware performance counter configuration for
+        /// counting "hardware interrupts" (documented or not).
+        fn irqs_counter_config(&self) -> Result<u32, Box<dyn Error + Send + Sync>> {
+            match self {
+                CpuModel::Amd(model) => match model {
+                    AmdGen::PreZen => Ok(0x00_cf),
+                    AmdGen::Zen | AmdGen::UnknownMaybeZenLike => Ok(0x00_2c),
+                },
+                CpuModel::Intel(model) => match model {
+                    IntelGen::PreBridge => Err(format!(
+                        "counting IRQs not yet supported on Intel CPUs \
+                         predating Sandy Bridge; {}",
+                        super::BUG_REPORT_MSG
+                    )
+                    .into()),
+                    IntelGen::Bridge
+                    | IntelGen::Well
+                    | IntelGen::Lake
+                    | IntelGen::UnknownMaybeLakeLike => Ok(0x01_cb),
+                },
+            }
+        }
+    }
+}
+
+#[cfg(not(all(feature = "nightly", target_arch = "x86_64", target_os = "linux")))]
+mod hw {
+    use std::error::Error;
+
+    pub(super) enum Counter {}
+
+    impl Counter {
+        pub(super) fn new(
+            model: &CpuModel,
+            _: super::HwCounterType,
+        ) -> Result<Self, Box<dyn Error + Send + Sync>> {
+            match *model {}
+        }
+    }
+
+    impl super::HwCounterRead for Counter {
+        type Output = u64;
+
+        #[inline]
+        fn read(&self) -> u64 {
+            match *self {}
+        }
+    }
+
+    impl super::HwCounterRead for (&Counter, &Counter) {
+        type Output = (u64, u64);
+
+        #[inline]
+        fn read(&self) -> (u64, u64) {
+            match *self.0 {}
+        }
+    }
+
+    pub(super) enum CpuModel {}
+
+    impl CpuModel {
+        pub(super) fn detect() -> Result<Self, Box<dyn Error + Send + Sync>> {
+            // HACK(eddyb) mark `really_warn!` (and transitively `log` macros)
+            // and `BUG_REPORT_MSG` as "used" to silence warnings.
+            if false {
+                really_warn!("unsupported; {}", super::BUG_REPORT_MSG);
+            }
+
+            let mut msg = String::new();
+            let mut add_error = |s| {
+                if !msg.is_empty() {
+                    msg += "; ";
+                }
+                msg += s;
+            };
+
+            if cfg!(not(feature = "nightly")) {
+                add_error("only supported with measureme's \"nightly\" feature");
+            }
+
+            if cfg!(not(target_arch = "x86_64")) {
+                add_error("only supported architecture is x86_64");
+            }
+
+            if cfg!(not(target_os = "linux")) {
+                add_error("only supported OS is Linux");
+            }
+
+            Err(msg.into())
+        }
+    }
+}

--- a/measureme/src/lib.rs
+++ b/measureme/src/lib.rs
@@ -37,7 +37,12 @@
 //! [`StringId`]: StringId
 #![allow(renamed_and_removed_lints)] // intra_doc_link_resolution_failure is renamed on nightly
 #![deny(warnings, intra_doc_link_resolution_failure)]
+#![cfg_attr(feature = "nightly", feature(asm))]
 
+#[macro_use]
+extern crate log;
+
+pub mod counters;
 pub mod event_id;
 pub mod file_header;
 mod profiler;

--- a/measureme/src/lib.rs
+++ b/measureme/src/lib.rs
@@ -12,6 +12,10 @@
 //!
 //! To create a [`Profiler`], call the [`Profiler::new()`] function and provide a `Path` with
 //! the directory and file name for the trace files.
+//! Alternatively, call the [`Profiler::with_counter()`] function, to choose the [`Counter`]
+//! the profiler will use for events (whereas [`Profiler::new()`] defaults to `wall-time`).
+//!
+//! For more information on available counters, see the [`counters`] module documentation.
 //!
 //! To record an event, call the [`Profiler::record_instant_event()`] method, passing a few
 //! arguments:
@@ -28,12 +32,15 @@
 //!   - [`Profiler::alloc_string()`]: allocates a string and returns the [`StringId`] that refers
 //!     to it
 //!
+//! [`counters`]: counters
+//! [`Counter`]: counters::Counter
 //! [`Profiler`]: Profiler
 //! [`Profiler::alloc_string()`]: Profiler::alloc_string
 //! [`Profiler::alloc_string_with_reserved_id()`]: Profiler::alloc_string_with_reserved_id
 //! [`Profiler::new()`]: Profiler::new
 //! [`Profiler::record_event()`]: Profiler::record_event
 //! [`Profiler::start_recording_interval_event()`]: Profiler::start_recording_interval_event
+//! [`Profiler::with_counter()`]: Profiler::with_counter
 //! [`StringId`]: StringId
 #![allow(renamed_and_removed_lints)] // intra_doc_link_resolution_failure is renamed on nightly
 #![deny(warnings, intra_doc_link_resolution_failure)]

--- a/measureme/src/profiler.rs
+++ b/measureme/src/profiler.rs
@@ -19,10 +19,7 @@ impl Profiler {
     pub fn new<P: AsRef<Path>>(path_stem: P) -> Result<Profiler, Box<dyn Error + Send + Sync>> {
         Self::with_counter(
             path_stem,
-            Counter::WallTime(
-                crate::counters::InstructionsMinusIrqs::new()?,
-                crate::counters::WallTime::new(),
-            ),
+            Counter::WallTime(crate::counters::WallTime::new()),
         )
     }
 

--- a/measureme/src/profiler.rs
+++ b/measureme/src/profiler.rs
@@ -19,7 +19,10 @@ impl Profiler {
     pub fn new<P: AsRef<Path>>(path_stem: P) -> Result<Profiler, Box<dyn Error + Send + Sync>> {
         Self::with_counter(
             path_stem,
-            Counter::WallTime(crate::counters::WallTime::new()),
+            Counter::WallTime(
+                crate::counters::InstructionsMinusIrqs::new()?,
+                crate::counters::WallTime::new(),
+            ),
         )
     }
 


### PR DESCRIPTION
*Note: this is a companion to https://github.com/rust-lang/rust/pull/78781, and duplicates some information with it for convenience*

## Credits

I'd like to start by thanking @alyssais, @cuviper, @edef1c, @glandium, @jix, @Mark-Simulacrum, @m-ou-se, @mystor, @nagisa, @puckipedia, and @yorickvP, for all of their help with testing, and valuable insight and suggestions.
Getting here wouldn't have been possible without you!

(If I've forgotten anyone please let me know, I'm going off memory here, plus some discussion logs)

## Summary

This PR adds support for counting hardware events such as "instructions retired" (as opposed to being limited to time measurements), using the `rdpmc` instruction on `x86_64` Linux.
Additionally, as `asm!` is used, `measureme` needs to built with nightly Rust, and with `features = ["nightly"]`, for the support to be enabled.

While other OSes may eventually be supported, preliminary research suggests some kind of kernel extension/driver is required to enable this, whereas on Linux any user can profile (at least) their own threads.

Supporting Linux on architectures other than x86_64 should be much easier (provided the hardware supports such performance counters), and was mostly not done due to a lack of readily available test hardware.
That said, 32-bit `x86` (aka `i686`) would be almost trivial to add and test once we land the initial `x86_64` version (as all the CPU detection code can be reused).

These new APIs were (backwards-compatibly) added to `measureme`:
* `counters` module holding `Counter` and all the counters implemented so far
    * attempting to create a counter may return `Err` if unsupported, but are not `#[cfg]`'d out at compile-time
* `Counter::by_name` creates a `Counter` based on its name
    * this is only to avoid needing to reimplement this in users of `measureme` which want to expose the counter names (e.g. `rustc` via a `-Z self-profile-counter` flag)
* `Profiler::with_counter` taking the `Counter` to use for event endpoints
    * the existing `Profiler::new` continues to default to measuring time (i.e. equivalent to `Profiler::with_counter(Counter::by_name("wall-time").unwrap())`)
    * a `Profiler` is currently limited to one `Counter` but long-term we could adjust the binary format to allow including several counters' values in a `measureme` event

Information about counters (name and units) is included in the JSON blob describing the profile data, which should still allow unupdated tools to read the new profiles (but they would report e.g. instructions as nanoseconds).
The backwards compatibility aspect was more important before the recent breaking change was introduced (for using just one file instead of 3, per profile), though avoiding breaking changes still seems good practice here.

The named counters so far are:
* `wall-time`: the existing time measurement
    * name chosen for consistency with `perf.rust-lang.org`
    * continues to use `std::time::Instant` for a nanosecond-precision "monotonic clock"
* `instructions:u`: the hardware performance counter usually referred to as "Instructions retired"
    * here "retired" (roughly) means "fully executed"
    * the `:u` suffix is from the Linux `perf` tool and indicates the counter only runs while userspace code is executing, and therefore counts no kernel instructions
        * *see [Caveats/Subtracting IRQs](https://hackmd.io/sH315lO2RuicY-SEt7ynGA?view#Subtracting-IRQs) for why this isn't entirely true and why `instructions-minus-irqs:u` should be preferred instead*
* `instructions-minus-irqs:u`: same as `instructions:u`, except the count of hardware interrupts ("IRQs" here for brevity) is subtracted
    * *see [Caveats/Subtracting IRQs](https://hackmd.io/sH315lO2RuicY-SEt7ynGA?view#Subtracting-IRQs) for why this should be preferred over `instructions:u`*
* `instructions-minus-r0420:u`: experimental counter, same as `instructions-minus-irqs:u` but subtracting an undocumented counter (`r0420:u`) instead of IRQs
    * the `rXXXX` notation is again from Linux `perf`, and indicates a "raw" counter, with a hex representation of the low-level counter configuration - this was picked because we still don't *really* know what it is
    * this only exists for (future) testing and isn't included/used in any comparisons/data we've put together so far
    * *see [Challenges/Zen's undocumented 420 counter](https://hackmd.io/sH315lO2RuicY-SEt7ynGA?view#Epilogue-Zen’s-undocumented-420-counter) for details on how this counter was found and what it does*

---

#### Write-up / report

Because of how extensive the full report ended up being, I've kept most of it [on `hackmd.io`](https://hackmd.io/sH315lO2RuicY-SEt7ynGA?view), but for convenient access, here are all the sections (with individual links):
<sup>(someone suggested I'd make a backup, so [here it is on the wayback machine](http://web.archive.org/web/20201103104237/https://hackmd.io/sH315lO2RuicY-SEt7ynGA?view) - I'll need to remember to update that if I have to edit the write-up)</sup>

* [**Motivation**](https://hackmd.io/sH315lO2RuicY-SEt7ynGA?view#Motivation)

* [**Results**](https://hackmd.io/sH315lO2RuicY-SEt7ynGA?view#Results)
    * [**Overhead**](https://hackmd.io/sH315lO2RuicY-SEt7ynGA?view#Overhead)
    *Preview (see the report itself for more details):*

    |Counter|Total<br>`instructions-minus-irqs:u`|Overhead from "Baseline"<br>(for all 1903881<br>counter reads)|Overhead from "Baseline"<br>(per each counter read)|
    |-|-|-|-|
    |Baseline|63637621286 ±6||
    |`instructions:u`|63658815885 ±2|&nbsp;&nbsp;+21194599 ±8|&nbsp;&nbsp;+11|
    |`instructions-minus-irqs:u`|63680307361 ±13|&nbsp;&nbsp;+42686075 ±19|&nbsp;&nbsp;+22|
    |`wall-time`|63951958376 ±10275|+314337090 ±10281|+165|

    * [**"Macro" noise (self time)**](https://hackmd.io/sH315lO2RuicY-SEt7ynGA?view#“Macro”-noise-(self-time))
    *Preview (see the report itself for more details):*

    || `wall-time` (ns) | `instructions:u` | `instructions-minus-irqs:u`
    -: | -: | -: | -:
    `typeck` | 5478261360 ±283933373 (±~5.2%) | 17350144522 ±6392 (±~0.00004%) | 17351035832.5 ±4.5 (±~0.00000003%)
    `expand_crate` | 2342096719 ±110465856 (±~4.7%) | 8263777916 ±2937 (±~0.00004%) | 8263708389 ±0 (±~0%)
    `mir_borrowck` | 2216149671 ±119458444 (±~5.4%) | 8340920100 ±2794 (±~0.00003%) | 8341613983.5 ±2.5 (±~0.00000003%)
    `mir_built` | 1269059734 ±91514604 (±~7.2%) | 4454959122 ±1618 (±~0.00004%) | 4455303811 ±1 (±~0.00000002%)
    `resolve_crate` | 942154987.5 ±53068423.5 (±~5.6%) | 3951197709 ±39 (±~0.000001%) | 3951196865 ±0 (±~0%)

    * [**"Micro" noise (individual sampling intervals)**](https://hackmd.io/sH315lO2RuicY-SEt7ynGA?view#“Micro”-noise-(individual-sampling-intervals))

* [**Caveats**](https://hackmd.io/sH315lO2RuicY-SEt7ynGA?view#Caveats)
    * [**Disabling ASLR**](https://hackmd.io/sH315lO2RuicY-SEt7ynGA?view#Disabling-ASLR)
    * [**Non-deterministic proc macros**](https://hackmd.io/sH315lO2RuicY-SEt7ynGA?view#Non-deterministic-proc-macros)
    * [**Subtracting IRQs**](https://hackmd.io/sH315lO2RuicY-SEt7ynGA?view#Subtracting-IRQs)
    * [**Lack of support for multiple threads**](https://hackmd.io/sH315lO2RuicY-SEt7ynGA?view#Lack-of-support-for-multiple-threads)

* [**Challenges**](https://hackmd.io/sH315lO2RuicY-SEt7ynGA?view#Challenges)
    * [**How do we even read hardware performance counters?**](https://hackmd.io/sH315lO2RuicY-SEt7ynGA?view#How-do-we-even-read-hardware-performance-counters)
    * [**ASLR: it's free entropy**](https://hackmd.io/sH315lO2RuicY-SEt7ynGA?view#ASLR-it’s-free-entropy)
    * [**The serializing instruction**](https://hackmd.io/sH315lO2RuicY-SEt7ynGA?view#The-serializing-instruction)
    * [**Getting constantly interrupted**](https://hackmd.io/sH315lO2RuicY-SEt7ynGA?view#Getting-constantly-interrupted)
    * [**AMD patented time-travel and dubbed it `SpecLockMap`<br><sup>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;or: "how we accidentally unlocked `rr` on AMD Zen"</sup>**](https://hackmd.io/sH315lO2RuicY-SEt7ynGA?view#AMD-patented-time-travel-and-dubbed-it-SpecLockMapnbspnbspnbspnbspnbspnbspnbspnbspor-“how-we-accidentally-unlocked-rr-on-AMD-Zen”)
    * [**`jemalloc`: purging will commence in ten seconds**](https://hackmd.io/sH315lO2RuicY-SEt7ynGA?view#jemalloc-purging-will-commence-in-ten-seconds)
    * [**Rebasing *shouldn't* affect the results, right?**](https://hackmd.io/sH315lO2RuicY-SEt7ynGA?view#Rebasing-*shouldn’t*-affect-the-results,-right)
    * [**Epilogue: Zen's undocumented 420 counter**](https://hackmd.io/sH315lO2RuicY-SEt7ynGA?view#Epilogue-Zen’s-undocumented-420-counter)