### PR TITLE
add to invocation count for blocked events

### DIFF
--- a/summarize/src/analysis.rs
+++ b/summarize/src/analysis.rs
@@ -204,6 +204,7 @@ pub fn perform_analysis(data: ProfilingData) -> Results {
                             data.self_time += current_event_duration;
                             data.time += current_event_duration;
                             data.blocked_time += current_event_duration;
+                            data.invocation_count += 1;
                         });
                     }
 


### PR DESCRIPTION
as the time for blocked events is increased think that also the invocation count shall be increased.

was confused when looking at the result from https://github.com/rust-lang/rust/pull/79706 where parallell compiler is tested,
some queries was taking long time when running in parallell so was looking in the query after the problem as the invocation count was 1, but in many cases the problem was that the same query was executed in multiple threads at the same time resulting in blocked query events.