### PR TITLE
Crox: Collect mm_profiledata files in directory

### DIFF
--- a/crox/src/main.rs
+++ b/crox/src/main.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use analyzeme::{ProfilingData, Timestamp};
+use measureme::file_header::FILE_EXTENSION;
 
 use serde::ser::SerializeSeq;
 use serde::{Serialize, Serializer};
@@ -219,7 +220,7 @@ fn file_prefixes_in_dir(opt: &Opt) -> Result<Vec<PathBuf>, std::io::Error> {
         for entry in fs::read_dir(dir_path)? {
             let entry = entry?;
             let path = entry.path();
-            if path.extension().filter(|e| *e == "events").is_some() {
+            if path.extension().filter(|e| *e == FILE_EXTENSION).is_some() {
                 result.push(path)
             }
         }


### PR DESCRIPTION
Hopefully closes #154 

Untested, but I think should be fine. Previously, `crox --dir <dir>` was looking for `.events` files, while `ProfileData` (and AFAICS everything else) works with `mm_profiledata`. This PR updates the file extension filter so that `crox --dir` may generate results without having to rename the world.