### PR TITLE
Update memmap to memmap2.

### DIFF
--- a/measureme/Cargo.toml
+++ b/measureme/Cargo.toml
@@ -22,5 +22,5 @@ smallvec = "1.0"
 nightly = []
 
 [target.'cfg(all(target_arch = "x86_64", target_os = "linux"))'.dependencies]
-memmap = "0.7"
+memmap2 = "0.2.1"
 perf-event-open-sys = "1.0.1"

--- a/measureme/src/counters.rs
+++ b/measureme/src/counters.rs
@@ -302,7 +302,7 @@ const BUG_REPORT_MSG: &str =
 /// Linux x86_64 implementation based on `perf_event_open` and `rdpmc`.
 #[cfg(all(feature = "nightly", target_arch = "x86_64", target_os = "linux"))]
 mod hw {
-    use memmap::{Mmap, MmapOptions};
+    use memmap2::{Mmap, MmapOptions};
     use perf_event_open_sys::{bindings::*, perf_event_open};
     use std::convert::TryInto;
     use std::error::Error;


### PR DESCRIPTION
memmap is no longer maintained. memmap2 is a fork that is still maintained. https://rustsec.org/advisories/RUSTSEC-2020-0077.html

cc  https://github.com/rust-lang/rust/pull/83236

Fixes #153