### PR TITLE
Add instant and integer payload events to end-to-end serialization tests.

### DIFF
--- a/analyzeme/src/stack_collapse.rs
+++ b/analyzeme/src/stack_collapse.rs
@@ -121,7 +121,8 @@ mod test {
         b.interval("Query", "e2", 0, 3, 9, |b| {
             b.interval("Query", "e1", 0, 4, 8, |b| {
                 b.interval("Query", "e3", 0, 5, 7, |_| {});
-                b.integer("ArtifactSize", "e3", 0, 100);
+                // Integer events are expected to be ignored
+                b.integer("ArtifactSize", "e4", 0, 100);
             });
         });
 


### PR DESCRIPTION
This PR mixes events with instant-timestamps and integer payloads into the serialization test streams.

r? @wesleywiser 