### PR TITLE
Update all crates to version 10.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [10.0.0] - 2021-09-06
+### Added
+- `measureme`: Add integer event support ([GH-169])
+- `summarize`: Add integer event support ([GH-169])
+- `summarize`: Add incremental compilation result hashing profiling ([GH-166])
+
 ## [9.1.2] - 2021-05-21
 ### Added
 - `measureme`: Allow recording interval events without using the drop guard ([GH-159])
@@ -143,3 +149,5 @@
 [GH-155]: https://github.com/rust-lang/measureme/pull/155
 [GH-156]: https://github.com/rust-lang/measureme/pull/156
 [GH-159]: https://github.com/rust-lang/measureme/pull/159
+[GH-166]: https://github.com/rust-lang/measureme/pull/166
+[GH-169]: https://github.com/rust-lang/measureme/pull/169

--- a/analyzeme/Cargo.toml
+++ b/analyzeme/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "analyzeme"
-version = "9.1.2"
+version = "10.0.0"
 authors = ["Wesley Wiser <wwiser@gmail.com>", "Michael Woerister <michaelwoerister@posteo>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/crox/Cargo.toml
+++ b/crox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crox"
-version = "9.1.2"
+version = "10.0.0"
 authors = ["Wesley Wiser <wwiser@gmail.com>"]
 edition = "2018"
 

--- a/flamegraph/Cargo.toml
+++ b/flamegraph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flamegraph"
-version = "9.1.2"
+version = "10.0.0"
 authors = ["Wesley Wiser <wwiser@gmail.com>", "Michael Woerister <michaelwoerister@posteo>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/measureme/Cargo.toml
+++ b/measureme/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "measureme"
-version = "9.1.2"
+version = "10.0.0"
 authors = ["Wesley Wiser <wwiser@gmail.com>", "Michael Woerister <michaelwoerister@posteo>"]
 edition = "2018"
 description = "Support crate for rustc's self-profiling feature"

--- a/measureme/src/file_header.rs
+++ b/measureme/src/file_header.rs
@@ -5,7 +5,7 @@ use std::convert::TryInto;
 use std::error::Error;
 use std::path::Path;
 
-pub const CURRENT_FILE_FORMAT_VERSION: u32 = 7;
+pub const CURRENT_FILE_FORMAT_VERSION: u32 = 8;
 
 pub const FILE_MAGIC_TOP_LEVEL: &[u8; 4] = b"MMPD";
 pub const FILE_MAGIC_EVENT_STREAM: &[u8; 4] = b"MMES";

--- a/mmview/Cargo.toml
+++ b/mmview/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mmview"
-version = "9.1.2"
+version = "10.0.0"
 authors = ["Wesley Wiser <wwiser@gmail.com>", "Michael Woerister <michaelwoerister@posteo>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/stack_collapse/Cargo.toml
+++ b/stack_collapse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stack_collapse"
-version = "9.1.2"
+version = "10.0.0"
 authors = ["Wesley Wiser <wwiser@gmail.com>", "Michael Woerister <michaelwoerister@posteo>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/summarize/Cargo.toml
+++ b/summarize/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "summarize"
-version = "9.1.2"
+version = "10.0.0"
 authors = ["Wesley Wiser <wwiser@gmail.com>", "Michael Woerister <michaelwoerister@posteo>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/version_checker/Cargo.toml
+++ b/version_checker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "version_checker"
-version = "9.1.2"
+version = "10.0.0"
 authors = ["Michael Woerister <michaelwoerister@posteo>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
New version of measureme and co. See the changelog for what's new. 

The version has been bumped to a new major version because some of the changes were breaking changes. 