### PR TITLE
Check the artifact size event kind in summarize

### DIFF
--- a/measureme/src/rustc.rs
+++ b/measureme/src/rustc.rs
@@ -11,3 +11,5 @@ pub const INCREMENTAL_RESULT_HASHING_EVENT_KIND: &str = "IncrementalResultHashin
 pub const QUERY_BLOCKED_EVENT_KIND: &str = "QueryBlocked";
 
 pub const QUERY_CACHE_HIT_EVENT_KIND: &str = "QueryCacheHit";
+
+pub const ARTIFACT_SIZE_EVENT_KIND: &str = "ArtifactSize";

--- a/summarize/src/analysis.rs
+++ b/summarize/src/analysis.rs
@@ -254,7 +254,9 @@ pub fn perform_analysis(data: ProfilingData) -> Results {
                 thread.stack.push(current_event)
             }
             EventPayload::Integer(value) => {
-                artifact_sizes.push(ArtifactSize::new(current_event.label.into_owned(), value))
+                if current_event.event_kind == measureme::rustc::ARTIFACT_SIZE_EVENT_KIND {
+                    artifact_sizes.push(ArtifactSize::new(current_event.label.into_owned(), value))
+                }
             }
         }
     }

--- a/summarize/src/analysis.rs
+++ b/summarize/src/analysis.rs
@@ -254,7 +254,7 @@ pub fn perform_analysis(data: ProfilingData) -> Results {
                 thread.stack.push(current_event)
             }
             EventPayload::Integer(value) => {
-                if current_event.event_kind == measureme::rustc::ARTIFACT_SIZE_EVENT_KIND {
+                if current_event.event_kind == ARTIFACT_SIZE_EVENT_KIND {
                     artifact_sizes.push(ArtifactSize::new(current_event.label.into_owned(), value))
                 }
             }


### PR DESCRIPTION
This makes it so that in summarize we only add to the artifact size if that event label is "ArtifactSize"