### PR TITLE
Dedup artifact sizes by label when summarizing

### DIFF
--- a/summarize/src/analysis.rs
+++ b/summarize/src/analysis.rs
@@ -583,6 +583,7 @@ mod tests {
         b.integer(ARTIFACT_SIZE_EVENT_KIND, "artifact1", 1, 100);
         b.integer(ARTIFACT_SIZE_EVENT_KIND, "artifact1", 2, 50);
         b.integer(ARTIFACT_SIZE_EVENT_KIND, "artifact2", 1, 50);
+        b.integer("OTHER_EVENT", "other_id", 1, 50);
 
         let results = perform_analysis(b.into_profiling_data());
 

--- a/summarize/src/query_data.rs
+++ b/summarize/src/query_data.rs
@@ -144,8 +144,8 @@ pub struct ArtifactSize {
 }
 
 impl ArtifactSize {
-    pub fn new(label: String, value: u64) -> Self {
-        Self { label, value }
+    pub fn new(label: String) -> Self {
+        Self { label, value: 0 }
     }
 
     pub fn invert(&self) -> ArtifactSizeDiff {
@@ -160,6 +160,10 @@ impl ArtifactSize {
             label: self.label.clone(),
             size_change: self.value as i64,
         }
+    }
+
+    pub(crate) fn add_value(&mut self, value: u64) {
+        self.value += value;
     }
 }
 

--- a/summarize/src/query_data.rs
+++ b/summarize/src/query_data.rs
@@ -135,6 +135,13 @@ impl Results {
     pub fn query_data_by_label(&self, label: &str) -> &QueryData {
         self.query_data.iter().find(|qd| qd.label == label).unwrap()
     }
+
+    pub fn artifact_size_by_label(&self, label: &str) -> &ArtifactSize {
+        self.artifact_sizes
+            .iter()
+            .find(|qd| qd.label == label)
+            .unwrap()
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]


### PR DESCRIPTION
Artifact size events can have the same label. When summarizing we should dedup these events by their label. 