### PR TITLE
Install instructions should point to using latest version which works

### DIFF
--- a/crox/Readme.md
+++ b/crox/Readme.md
@@ -17,7 +17,7 @@ $ cargo rustc -- -Z self-profile
 
 ```
 $ # Install crox if you haven't done so yet.
-$ cargo install --git https://github.com/rust-lang/measureme crox
+$ cargo install --git https://github.com/rust-lang/measureme --tag 9.1.2 crox
 
 $ crox {crate name}-{pid}.mm_profdata
 ```

--- a/flamegraph/README.md
+++ b/flamegraph/README.md
@@ -7,7 +7,7 @@ flamegraph is a tool to produce [Flame Graph](https://github.com/brendangregg/Fl
 ```bash
 # Install flamegraph if you haven't done so yet.
 
-$ cargo install --git https://github.com/rust-lang/measureme flamegraph
+$ cargo install --git https://github.com/rust-lang/measureme --tag 9.1.2 flamegraph
 
 $ git clone https://github.com/rust-lang/regex.git
 

--- a/stack_collapse/README.md
+++ b/stack_collapse/README.md
@@ -7,7 +7,7 @@ stack-collapse is a tool to produce [Flame Graph](https://github.com/brendangreg
 ```bash
 $ # Install stack_collapse if you haven't done so yet.
 
-$ cargo install --git https://github.com/rust-lang/measureme stack_collapse
+$ cargo install --git https://github.com/rust-lang/measureme --tag 9.1.2 stack_collapse
 
 $ git clone https://github.com/rust-lang/regex.git
 

--- a/summarize/Readme.md
+++ b/summarize/Readme.md
@@ -7,7 +7,7 @@ Summarize is a tool to produce a human readable summary of `measureme` profiling
 To use this tool you will first want to install it:
 
 ```bash
-$ cargo install --git https://github.com/rust-lang/measureme summarize
+$ cargo install --git https://github.com/rust-lang/measureme --tag 9.1.2 summarize
 ```
 
 ## Profiling the nightly compiler


### PR DESCRIPTION
The master branch sometimes contains breaking changes that will not work when run against artifacts created by the latest nightly compiler. We should encourage users to install the latest version that we know works with nightly rustc. Right now that is version 9.1.2