### PR TITLE
Prepare 9.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [9.2.0] - 2021-05-21
+### Changed
+- `analyzeme`: Makes a couple of methods in ProfilingData public. ([GH-180])
+
 ## [9.1.2] - 2021-05-21
 ### Added
 - `measureme`: Allow recording interval events without using the drop guard ([GH-159])
@@ -92,6 +96,7 @@
 
 ## [0.2.0] - 2019-04-10
 
+[9.2.0]: https://github.com/rust-lang/measureme/releases/tag/9.2.0
 [9.1.2]: https://github.com/rust-lang/measureme/releases/tag/9.1.2
 [9.1.1]: https://github.com/rust-lang/measureme/releases/tag/9.1.1
 [9.1.0]: https://github.com/rust-lang/measureme/releases/tag/9.1.0
@@ -143,3 +148,4 @@
 [GH-155]: https://github.com/rust-lang/measureme/pull/155
 [GH-156]: https://github.com/rust-lang/measureme/pull/156
 [GH-159]: https://github.com/rust-lang/measureme/pull/159
+[GH-180]: https://github.com/rust-lang/measureme/pull/180

--- a/analyzeme/Cargo.toml
+++ b/analyzeme/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "analyzeme"
-version = "9.1.2"
+version = "9.2.0"
 authors = ["Wesley Wiser <wwiser@gmail.com>", "Michael Woerister <michaelwoerister@posteo>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/analyzeme/src/lib.rs
+++ b/analyzeme/src/lib.rs
@@ -25,9 +25,8 @@ pub use crate::stack_collapse::collapse_stacks;
 pub use crate::stringtable::{StringRef, StringTable};
 pub use crate::timestamp::Timestamp;
 
-
 // These are re-exported just for being used in v10.0.0 when supporting
 // old file formats. Starting in v10.0.0 these re-exports will become
 // part of the `decodeme` crate.
-pub use measureme::RawEvent;
 pub use measureme::file_header::CURRENT_FILE_FORMAT_VERSION;
+pub use measureme::RawEvent;

--- a/analyzeme/src/lib.rs
+++ b/analyzeme/src/lib.rs
@@ -24,3 +24,10 @@ pub use crate::profiling_data::{ProfilingData, ProfilingDataBuilder};
 pub use crate::stack_collapse::collapse_stacks;
 pub use crate::stringtable::{StringRef, StringTable};
 pub use crate::timestamp::Timestamp;
+
+
+// These are re-exported just for being used in v10.0.0 when supporting
+// old file formats. Starting in v10.0.0 these re-exports will become
+// part of the `decodeme` crate.
+pub use measureme::RawEvent;
+pub use measureme::file_header::CURRENT_FILE_FORMAT_VERSION;

--- a/analyzeme/src/profiling_data.rs
+++ b/analyzeme/src/profiling_data.rs
@@ -132,7 +132,7 @@ impl ProfilingData {
         event_byte_count / RAW_EVENT_SIZE
     }
 
-    pub(crate) fn decode_full_event<'a>(&'a self, event_index: usize) -> Event<'a> {
+    pub fn decode_full_event<'a>(&'a self, event_index: usize) -> Event<'a> {
         let event_start_addr = event_index_to_addr(event_index);
         let event_end_addr = event_start_addr.checked_add(RAW_EVENT_SIZE).unwrap();
 
@@ -158,7 +158,7 @@ impl ProfilingData {
         }
     }
 
-    fn decode_lightweight_event<'a>(&'a self, event_index: usize) -> LightweightEvent<'a> {
+    pub fn decode_lightweight_event<'a>(&'a self, event_index: usize) -> LightweightEvent<'a> {
         let event_start_addr = event_index_to_addr(event_index);
         let event_end_addr = event_start_addr.checked_add(RAW_EVENT_SIZE).unwrap();
 

--- a/crox/Cargo.toml
+++ b/crox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crox"
-version = "9.1.2"
+version = "9.2.0"
 authors = ["Wesley Wiser <wwiser@gmail.com>"]
 edition = "2018"
 

--- a/flamegraph/Cargo.toml
+++ b/flamegraph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flamegraph"
-version = "9.1.2"
+version = "9.2.0"
 authors = ["Wesley Wiser <wwiser@gmail.com>", "Michael Woerister <michaelwoerister@posteo>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/measureme/Cargo.toml
+++ b/measureme/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "measureme"
-version = "9.1.2"
+version = "9.2.0"
 authors = ["Wesley Wiser <wwiser@gmail.com>", "Michael Woerister <michaelwoerister@posteo>"]
 edition = "2018"
 description = "Support crate for rustc's self-profiling feature"

--- a/measureme/src/lib.rs
+++ b/measureme/src/lib.rs
@@ -50,7 +50,7 @@ pub mod stringtable;
 pub mod rustc;
 
 pub use crate::event_id::{EventId, EventIdBuilder};
-pub use crate::profiler::{Profiler, TimingGuard, DetachedTiming};
+pub use crate::profiler::{DetachedTiming, Profiler, TimingGuard};
 pub use crate::raw_event::{RawEvent, MAX_INSTANT_TIMESTAMP, MAX_INTERVAL_TIMESTAMP};
 pub use crate::serialization::{
     split_streams, Addr, PageTag, SerializationSink, SerializationSinkBuilder,

--- a/measureme/src/profiler.rs
+++ b/measureme/src/profiler.rs
@@ -135,7 +135,7 @@ impl Profiler {
         &self,
         event_kind: StringId,
         event_id: EventId,
-        thread_id: u32
+        thread_id: u32,
     ) -> DetachedTiming {
         DetachedTiming {
             event_id,
@@ -148,10 +148,7 @@ impl Profiler {
     /// Creates the corresponding "end" event for
     /// the "start" event represented by `timing`. You
     /// must have obtained `timing` from the same `Profiler`
-    pub fn finish_recording_interval_event(
-        &self,
-        timing: DetachedTiming
-    ) {
+    pub fn finish_recording_interval_event(&self, timing: DetachedTiming) {
         drop(TimingGuard {
             profiler: self,
             event_id: timing.event_id,

--- a/measureme/src/stringtable.rs
+++ b/measureme/src/stringtable.rs
@@ -186,7 +186,7 @@ impl<'s> StringComponent<'s> {
                 assert!(STRING_REF_ENCODED_SIZE == 5);
 
                 bytes[0] = STRING_REF_TAG;
-                &mut bytes[1..5].copy_from_slice(&string_id.0.to_le_bytes());
+                bytes[1..5].copy_from_slice(&string_id.0.to_le_bytes());
                 &mut bytes[5..]
             }
         }

--- a/mmview/Cargo.toml
+++ b/mmview/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mmview"
-version = "9.1.2"
+version = "9.2.0"
 authors = ["Wesley Wiser <wwiser@gmail.com>", "Michael Woerister <michaelwoerister@posteo>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/stack_collapse/Cargo.toml
+++ b/stack_collapse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stack_collapse"
-version = "9.1.2"
+version = "9.2.0"
 authors = ["Wesley Wiser <wwiser@gmail.com>", "Michael Woerister <michaelwoerister@posteo>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/summarize/Cargo.toml
+++ b/summarize/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "summarize"
-version = "9.1.2"
+version = "9.2.0"
 authors = ["Wesley Wiser <wwiser@gmail.com>", "Michael Woerister <michaelwoerister@posteo>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/version_checker/Cargo.toml
+++ b/version_checker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "version_checker"
-version = "9.1.2"
+version = "9.2.0"
 authors = ["Michael Woerister <michaelwoerister@posteo>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Makes a couple of methods in `ProfilingData` public in order to make it easier to start supporting older file formats in v10.0.0.

r? @rylev & @wesleywiser 