### PR TITLE
Add jobs to make bors able to detect success or failure

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,7 +2,10 @@ name: Rust
 
 on:
   push:
-    branches: [ master ]
+    branches: [ 
+      master,
+      auto    # used for bors 
+    ]
   pull_request:
     branches: [ master ]
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,7 +4,8 @@ on:
   push:
     branches: [ 
       master,
-      auto    # used for bors 
+      auto,   # used for bors
+      try     # used for bors
     ]
   pull_request:
     branches: [ master ]

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -84,3 +84,26 @@ jobs:
       with:
         command: check
         args: --verbose --lib --bins --tests
+
+  # These jobs doesn't actually test anything, but they're only used to tell
+  # bors the build completed, as there is no practical way to detect when a
+  # workflow is successful listening to webhooks only.
+  #
+  # ALL THE PREVIOUS JOBS NEED TO BE ADDED TO THE `needs` SECTION OF THIS JOB!
+  end-success:
+    name: bors build finished
+    runs-on: ubuntu-latest
+    needs: [build_stable, build_beta, build_nightly, check_big_endian]
+    if: github.event.pusher.name == 'bors' && success()
+    steps:
+      - name: mark the job as a success
+        run: exit 0
+
+  end-failure:
+    name: bors build finished
+    runs-on: ubuntu-latest
+    needs: [build_stable, build_beta, build_nightly, check_big_endian]
+    if: github.event.pusher.name == 'bors' && (failure() || cancelled())
+    steps:
+      - name: mark the job as a failure
+        run: exit 1


### PR DESCRIPTION
This is based on how [miri handles bors](https://github.com/rust-lang/miri/blob/6cf851f6d43bff1e8ac1421cbf3c6a8d20f89560/.github/workflows/ci.yml#L119-L140). 