### PR TITLE
counters: use AT&T inline asm syntax for older LLVM.

### DIFF
--- a/measureme/src/counters.rs
+++ b/measureme/src/counters.rs
@@ -805,10 +805,18 @@ mod hw {
                             let mut _tmp: u64 = 0;
                             unsafe {
                                 asm!(
-                                    "lock xadd qword ptr [{atomic}], {tmp}",
+                                    // Intel syntax: "lock xadd [{atomic}], {tmp}"
+                                    "lock xadd {tmp}, ({atomic})",
 
                                     atomic = in(reg) &mut atomic,
                                     tmp = inout(reg) _tmp,
+
+                                    // Older versions of LLVM do not support modifiers in
+                                    // Intel syntax inline asm; whenever Rust minimum LLVM
+                                    // version supports Intel syntax inline asm, remove
+                                    // and replace above instructions with Intel syntax
+                                    // version (from comments).
+                                    options(att_syntax),
                                 );
                             }
 


### PR DESCRIPTION
Rust minimum LLVM version still do not support Intel syntax inline asm

missed one in the last PR

r? @eddyb