### PR TITLE
Change install instructions to use stable branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# measureme [![Build Status](https://travis-ci.com/rust-lang/measureme.svg?branch=master)](https://travis-ci.com/rust-lang/measureme)
+# measureme [![Rust](https://github.com/rust-lang/measureme/actions/workflows/rust.yml/badge.svg)](https://github.com/rust-lang/measureme/actions/workflows/rust.yml)
 Support crate for rustc's self-profiling feature
 
 This crate is maintained by the Rust compiler team and in particular by the
@@ -21,7 +21,7 @@ It contains two main modes:
 - `summarize` which groups the profiling events and orders the results by time taken.
 - `diff` which compares two profiles and outputs a summary of the differences.
 
-[Learn more](./summarize/Readme.md)
+[Learn more](./summarize/README.md)
 
 ### stack_collapse
 
@@ -39,6 +39,6 @@ It contains two main modes:
 
 `crox` turns `measureme` profiling data into files that can be visualized by the Chromium performance tools.
 
-[Learn more](./crox/Readme.md)
+[Learn more](./crox/README.md)
 
 [wg-self-profile]: https://rust-lang.github.io/compiler-team/working-groups/self-profile/

--- a/crox/Cargo.toml
+++ b/crox/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Wesley Wiser <wwiser@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-measureme = { "path" = "../measureme" }
+measureme = { path = "../measureme" }
 analyzeme = { path = "../analyzeme" }
 rustc-hash = "1.0.1"
 serde = { version = "1.0", features = [ "derive" ] }

--- a/crox/README.md
+++ b/crox/README.md
@@ -17,7 +17,7 @@ $ cargo rustc -- -Z self-profile
 
 ```
 $ # Install crox if you haven't done so yet.
-$ cargo install --git https://github.com/rust-lang/measureme --tag 9.1.2 crox
+$ cargo install --git https://github.com/rust-lang/measureme --branch stable crox
 
 $ crox {crate name}-{pid}.mm_profdata
 ```

--- a/flamegraph/README.md
+++ b/flamegraph/README.md
@@ -7,7 +7,7 @@ flamegraph is a tool to produce [Flame Graph](https://github.com/brendangregg/Fl
 ```bash
 # Install flamegraph if you haven't done so yet.
 
-$ cargo install --git https://github.com/rust-lang/measureme --tag 9.1.2 flamegraph
+$ cargo install --git https://github.com/rust-lang/measureme --branch stable flamegraph
 
 $ git clone https://github.com/rust-lang/regex.git
 

--- a/stack_collapse/README.md
+++ b/stack_collapse/README.md
@@ -7,7 +7,7 @@ stack-collapse is a tool to produce [Flame Graph](https://github.com/brendangreg
 ```bash
 $ # Install stack_collapse if you haven't done so yet.
 
-$ cargo install --git https://github.com/rust-lang/measureme --tag 9.1.2 stack_collapse
+$ cargo install --git https://github.com/rust-lang/measureme --branch stable stack_collapse
 
 $ git clone https://github.com/rust-lang/regex.git
 

--- a/summarize/README.md
+++ b/summarize/README.md
@@ -7,7 +7,7 @@ Summarize is a tool to produce a human readable summary of `measureme` profiling
 To use this tool you will first want to install it:
 
 ```bash
-$ cargo install --git https://github.com/rust-lang/measureme --tag 9.1.2 summarize
+$ cargo install --git https://github.com/rust-lang/measureme --branch stable summarize
 ```
 
 ## Profiling the nightly compiler


### PR DESCRIPTION
We now have a [stable](https://github.com/rust-lang/measureme/tree/stable) branch which points to the v10.0.0. We can now encourage folks to install off this branch instead of from a specific version or from master. 

(I also updated the READMEs with a few small fixes) 

r? @michaelwoerister 

Fixes #182 