### PR TITLE
Fix build warnings from Rust 2018 idioms

### DIFF
--- a/crox/src/main.rs
+++ b/crox/src/main.rs
@@ -120,7 +120,7 @@ fn generate_thread_to_collapsed_thread_mapping(
     thread_to_collapsed_thread
 }
 
-fn get_args(full_event: &analyzeme::Event) -> Option<FxHashMap<String, String>> {
+fn get_args(full_event: &analyzeme::Event<'_>) -> Option<FxHashMap<String, String>> {
     if !full_event.additional_data.is_empty() {
         Some(
             full_event

--- a/measureme/src/event_id.rs
+++ b/measureme/src/event_id.rs
@@ -83,7 +83,7 @@ impl<'p> EventIdBuilder<'p> {
 
     pub fn from_label_and_args(&self, label: StringId, args: &[StringId]) -> EventId {
         // Store up to 7 components on the stack: 1 label + 3 arguments + 3 argument separators
-        let mut parts = SmallVec::<[StringComponent; 7]>::with_capacity(1 + args.len() * 2);
+        let mut parts = SmallVec::<[StringComponent<'_>; 7]>::with_capacity(1 + args.len() * 2);
 
         parts.push(StringComponent::Ref(label));
 

--- a/summarize/src/aggregate.rs
+++ b/summarize/src/aggregate.rs
@@ -322,7 +322,7 @@ impl<'a, I: BackwardsIterator<Item = SampleInterval<WithParent<Event<'a>>>>> Bac
         match self.sample_intervals_per_profile.get_mut(0)?.next_back() {
             Some(interval) => {
                 let first_duration = interval.duration();
-                let descriptions = interval.map_event(WithParent::<EventDescription>::from);
+                let descriptions = interval.map_event(WithParent::<EventDescription<'_>>::from);
 
                 // FIXME(eddyb) maybe extract this part into an `Iterator` impl? but it
                 // would be hard to return an interable that doesn't allocate nor borrow
@@ -344,7 +344,7 @@ impl<'a, I: BackwardsIterator<Item = SampleInterval<WithParent<Event<'a>>>>> Bac
                         // of each profile are themselves identical.
                         assert_eq!(
                             descriptions,
-                            interval.map_event(WithParent::<EventDescription>::from),
+                            interval.map_event(WithParent::<EventDescription<'_>>::from),
                             "`summarize aggregate` requires identical sequences of events"
                         );
 

--- a/summarize/src/analysis.rs
+++ b/summarize/src/analysis.rs
@@ -118,7 +118,7 @@ pub fn perform_analysis(data: ProfilingData) -> Results {
 
     let mut query_data = FxHashMap::<String, QueryData>::default();
     let mut artifact_sizes = BTreeMap::<Cow<'_, str>, ArtifactSize>::default();
-    let mut threads = FxHashMap::<_, PerThreadState>::default();
+    let mut threads = FxHashMap::<_, PerThreadState<'_>>::default();
 
     let mut record_event_data = |label: &Cow<'_, str>, f: &dyn Fn(&mut QueryData)| {
         if let Some(data) = query_data.get_mut(&label[..]) {

--- a/summarize/src/signed_duration.rs
+++ b/summarize/src/signed_duration.rs
@@ -57,7 +57,7 @@ impl Sub for SignedDuration {
 }
 
 impl fmt::Debug for SignedDuration {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self.is_positive {
             write!(f, "+")?;
         } else {


### PR DESCRIPTION
Adds missing elided lifetimes, fixing warnings triggered by the `-Wrust_2018_idioms` flag.
