### PR TITLE
Remove malformed `serde` attribute

### DIFF
--- a/crox/src/main.rs
+++ b/crox/src/main.rs
@@ -32,7 +32,6 @@ struct Event {
     #[serde(rename = "ph")]
     event_type: EventType,
     #[serde(rename = "ts", serialize_with = "as_micros")]
-    #[serde()]
     timestamp: Duration,
     #[serde(rename = "dur", serialize_with = "as_micros")]
     duration: Duration,


### PR DESCRIPTION
```
error: unexpected end of input, unexpected token in nested attribute, expected ident
  --> crox/src/main.rs:35:13
   |
35 |     #[serde()]
   |     
```