### PR TITLE
Fix build with serde 1.0.157 and newer

### DIFF
--- a/crox/src/main.rs
+++ b/crox/src/main.rs
@@ -32,7 +32,6 @@ struct Event {
     #[serde(rename = "ph")]
     event_type: EventType,
     #[serde(rename = "ts", serialize_with = "as_micros")]
-    #[serde()]
     timestamp: Duration,
     #[serde(rename = "dur", serialize_with = "as_micros")]
     duration: Duration,


### PR DESCRIPTION
`serde` 1.0.157 and later rejects this particular attribute with the following error:

```
error: unexpected end of input, unexpected token in nested attribute, expected ident
  --> crox\src\main.rs:35:13
   |
35 |     #[serde()]
   |             ^

error[E0277]: the trait bound `Event: Serialize` is not satisfied
    --> crox\src\main.rs:175:35
     |
175  |             seq.serialize_element(&crox_event)?;
     |                 ----------------- ^^^^^^^^^^^ the trait `Serialize` is not implemented for `Event`
     |                 |
     |                 required by a bound introduced by this call
     |
     = help: the following other types implement trait `Serialize`:
               &'a T
               &'a mut T
               ()
               (T0, T1)
               (T0, T1, T2)
               (T0, T1, T2, T3)
               (T0, T1, T2, T3, T4)
               (T0, T1, T2, T3, T4, T5)
             and 131 others
note: required by a bound in `_serde::ser::SerializeSeq::serialize_element`
    --> C:\Users\jay\.cargo\registry\src\index.crates.io-6f17d22bba15001f\serde-1.0.157\src\ser\mod.rs:1534:12
     |
1534 |         T: Serialize;
     |            ^^^^^^^^^ required by this bound in `SerializeSeq::serialize_element`
```