### PR TITLE
Allow whitespace control chars in EventId texts.

### DIFF
--- a/measureme/src/event_id.rs
+++ b/measureme/src/event_id.rs
@@ -8,11 +8,11 @@ use crate::{Profiler, StringComponent, StringId};
 ///   <event_id> = <label> {<argument>}
 ///   <label> = <text>
 ///   <argument> = '\x1E' <text>
-///   <text> = regex([^[[:cntrl:]]]+) // Anything but ASCII control characters
+///   <text> = regex([[[:^cntrl:]][[:space:]]]+) // Anything but ASCII control characters except for whitespace.
 ///  ```
 ///
 /// This means there's always a "label", followed by an optional list of
-/// arguments. Future versions my support other optional suffixes (with a tag
+/// arguments. Future versions may support other optional suffixes (with a tag
 /// other than '\x11' after the '\x1E' separator), such as a "category".
 
 /// The byte used to separate arguments from the label and each other.


### PR DESCRIPTION
As it only seems that control chars is not allowed in the EventId texts is to allow for future tags I think excluding the whitespace control chars is ok.
What I can see right now the only tag used is for arguments and is '\x1E'.

fixes #207

cc @michaelwoerister 