### PR TITLE
bump parking_lot to 0.12 to sync with rustc

### DIFF
--- a/measureme/Cargo.toml
+++ b/measureme/Cargo.toml
@@ -14,7 +14,7 @@ travis-ci = { repository = "rust-lang/measureme" }
 
 [dependencies]
 log = "0.4"
-parking_lot = "0.11.0"
+parking_lot = "0.12.0"
 rustc-hash = "1.0.1"
 smallvec = "1.0"
 


### PR DESCRIPTION
Sync with https://github.com/rust-lang/rust/pull/114418