### PR TITLE
Prepare 11.0.0 release

### DIFF
--- a/analyzeme/src/testing_common.rs
+++ b/analyzeme/src/testing_common.rs
@@ -42,7 +42,7 @@ fn generate_profiling_data(
 ) -> Vec<Event<'static>> {
     let profiler = Arc::new(Profiler::new(Path::new(filestem)).unwrap());
 
-    let event_id_virtual = EventId::from_label(StringId::new_virtual(42));
+    let event_id_virtual = EventId::from_label(StringId::new_virtual(42u64));
     let event_id_builder = EventIdBuilder::new(&profiler);
 
     let event_ids: Vec<(StringId, EventId)> = vec![

--- a/measureme/src/stringtable.rs
+++ b/measureme/src/stringtable.rs
@@ -80,12 +80,13 @@ impl StringId {
     pub const INVALID: StringId = StringId(INVALID_STRING_ID);
 
     #[inline]
-    pub fn new(id: u64) -> StringId {
-        StringId(id)
+    pub fn new(id: impl Into<u64>) -> StringId {
+        StringId(id.into())
     }
 
     #[inline]
-    pub fn new_virtual(id: u64) -> StringId {
+    pub fn new_virtual(id: impl Into<u64>) -> StringId {
+        let id = id.into();
         assert!(id <= MAX_USER_VIRTUAL_STRING_ID);
         StringId(id)
     }


### PR DESCRIPTION
The change here makes `StringId::new` and `StringId::new_virtual` backwards compatible with 10.x, so that we don't require unnecessary churn when updating to 11.0.0.