### PR TITLE
Fix compilation error and regression tests for big endian platforms

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,11 +14,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         ref: stable
-    - uses: dtolnay/rust-toolchain@stable
-      with:
-        toolchain: nightly
+    - name: Set up Rust toolchain
+      run: rustup toolchain install --no-self-update --profile minimal nightly
     - name: Build
-      run: cargo build --all
+      run: cargo +nightly build --all
     - name: Generate self-profile
       run: RUSTFLAGS="-Zself-profile" cargo +nightly build --bin crox
     - name: Check crox

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         ref: stable
-    - uses: actions-rs/toolchain@v1
+    - uses: dtolnay/rust-toolchain@stable
       with:
         toolchain: nightly
     - name: Build

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,80 +14,27 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build_stable:
-
+  build:
+    strategy:
+      matrix:
+        rust_channel: [ stable, beta, nightly ]
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
+    - uses: actions/checkout@v4
+    - uses: dtolnay/rust-toolchain@stable
       with:
-        toolchain: stable
+        toolchain: ${{ matrix.rust_channel }}
+        # Add a big endian target so we can check that everything at least
+        # compiles on big endian.
+        targets: powerpc64-unknown-linux-gnu
     - name: Build
       run: cargo build --verbose --all
     - name: Run tests
       run: cargo test --verbose --all
     - name: Docs
       run: cargo doc --verbose --all
-
-  build_beta:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: beta
-        override: true
-    - uses: actions-rs/cargo@v1
-      with:
-        command: build
-        args: --verbose --all
-    - uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --verbose --all
-    - uses: actions-rs/cargo@v1
-      with:
-        command: doc
-        args: --verbose --all
-
-  build_nightly:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: nightly
-        override: true
-    - uses: actions-rs/cargo@v1
-      with:
-        command: build
-        args: --verbose --all -Zcheck-cfg
-    - uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --verbose --all -Zcheck-cfg
-    - uses: actions-rs/cargo@v1
-      with:
-        command: doc
-        args: --verbose --all
-
-  check_big_endian:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        target: powerpc64-unknown-linux-gnu
-        override: true
-    - uses: actions-rs/cargo@v1
-      with:
-        command: check
-        args: --verbose --lib --bins --tests
+    - name: Check big endian
+      run: cargo check --target powerpc64-unknown-linux-gnu --verbose --all
 
   # These jobs doesn't actually test anything, but they're only used to tell
   # bors the build completed, as there is no practical way to detect when a
@@ -97,7 +44,7 @@ jobs:
   end-success:
     name: bors build finished
     runs-on: ubuntu-latest
-    needs: [build_stable, build_beta, build_nightly, check_big_endian]
+    needs: [build]
     if: github.event.pusher.name == 'bors' && success()
     steps:
       - name: mark the job as a success
@@ -106,7 +53,7 @@ jobs:
   end-failure:
     name: bors build finished
     runs-on: ubuntu-latest
-    needs: [build_stable, build_beta, build_nightly, check_big_endian]
+    needs: [build]
     if: github.event.pusher.name == 'bors' && (failure() || cancelled())
     steps:
       - name: mark the job as a failure

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,6 +18,9 @@ jobs:
     strategy:
       matrix:
         rust_channel: [ stable, beta, nightly ]
+        include:
+          - rust_channel: nightly
+            check_cfg: '-Zcheck-cfg'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -28,9 +31,9 @@ jobs:
         # compiles on big endian.
         targets: powerpc64-unknown-linux-gnu
     - name: Build
-      run: cargo build --verbose --all
+      run: cargo build --verbose --all ${{ matrix.check_cfg }}
     - name: Run tests
-      run: cargo test --verbose --all
+      run: cargo test --verbose --all ${{ matrix.check_cfg }}
     - name: Docs
       run: cargo doc --verbose --all
     - name: Check big endian

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,25 +17,26 @@ jobs:
   build:
     strategy:
       matrix:
-        rust_channel: [ stable, beta, nightly ]
+        rust: [ stable, beta, nightly ]
         include:
-          - rust_channel: nightly
+          - rust: nightly
             check_cfg: '-Zcheck-cfg'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: dtolnay/rust-toolchain@stable
-      with:
-        toolchain: ${{ matrix.rust_channel }}
+    - name: Set up Rust toolchain
+      run: |
+        rustup toolchain install --no-self-update --profile minimal ${{ matrix.rust }}
+        rustup default ${{ matrix.rust }}
         # Add a big endian target so we can check that everything at least
         # compiles on big endian.
-        targets: powerpc64-unknown-linux-gnu
+        rustup target add --toolchain ${{ matrix.rust }} powerpc64-unknown-linux-gnu
     - name: Build
       run: cargo build --verbose --all ${{ matrix.check_cfg }}
     - name: Run tests
       run: cargo test --verbose --all ${{ matrix.check_cfg }}
     - name: Docs
-      run: cargo doc --verbose --all
+      run: cargo doc --verbose --no-deps
     - name: Check big endian
       run: cargo check --target powerpc64-unknown-linux-gnu --verbose --all
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,15 @@
 # Changelog
 
+## [11.0.1] - 2024-01-XX
+
+### Changed
+
+- `measureme`: Fix compilation error and regression tests for big endian platforms ([GH-220])
+
 ## [11.0.0] - 2023-12-14
 
 ### Changed
+
 - `measureme`: Update StringId and Addr sizes from u32 to u64 ([GH-216])
 - `analyzeme`: v9 file format, which uses larger events ([GH-216])
 
@@ -239,3 +246,4 @@
 [GH-209]: https://github.com/rust-lang/measureme/pull/209
 [GH-211]: https://github.com/rust-lang/measureme/pull/211
 [GH-216]: https://github.com/rust-lang/measureme/pull/216
+[GH-220]: https://github.com/rust-lang/measureme/pull/220

--- a/flamegraph/Cargo.toml
+++ b/flamegraph/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "flamegraph"
 version = "11.0.0"
-authors = ["Wesley Wiser <wwiser@gmail.com>", "Michael Woerister <michaelwoerister@posteo>"]
+authors = [
+    "Wesley Wiser <wwiser@gmail.com>",
+    "Michael Woerister <michaelwoerister@posteo>",
+]
 edition = "2018"
 license = "MIT OR Apache-2.0"
 
@@ -9,4 +12,4 @@ license = "MIT OR Apache-2.0"
 measureme = { path = "../measureme" }
 analyzeme = { path = "../analyzeme" }
 clap = { version = "3.2", features = ["derive"] }
-inferno = { version="0.9.1", default-features = false }
+inferno = { version = "0.11", default-features = false }

--- a/measureme/src/raw_event.rs
+++ b/measureme/src/raw_event.rs
@@ -154,12 +154,12 @@ impl RawEvent {
         {
             // We always emit data as little endian, which we have to do
             // manually on big endian targets.
-            bytes[0..4].copy_from_slice(&self.event_kind.as_u32().to_le_bytes());
-            bytes[4..8].copy_from_slice(&self.event_id.as_u32().to_le_bytes());
-            bytes[8..12].copy_from_slice(&self.thread_id.to_le_bytes());
-            bytes[12..16].copy_from_slice(&self.payload1_lower.to_le_bytes());
-            bytes[16..20].copy_from_slice(&self.payload2_lower.to_le_bytes());
-            bytes[20..24].copy_from_slice(&self.payloads_upper.to_le_bytes());
+            bytes[0..8].copy_from_slice(&self.event_kind.as_u64().to_le_bytes());
+            bytes[8..16].copy_from_slice(&self.event_id.as_u64().to_le_bytes());
+            bytes[16..20].copy_from_slice(&self.thread_id.to_le_bytes());
+            bytes[20..24].copy_from_slice(&self.payload1_lower.to_le_bytes());
+            bytes[24..28].copy_from_slice(&self.payload2_lower.to_le_bytes());
+            bytes[28..32].copy_from_slice(&self.payloads_upper.to_le_bytes());
         }
     }
 
@@ -183,12 +183,12 @@ impl RawEvent {
         #[cfg(target_endian = "big")]
         {
             RawEvent {
-                event_kind: StringId::new(u32::from_le_bytes(bytes[0..4].try_into().unwrap())),
-                event_id: EventId::from_u32(u32::from_le_bytes(bytes[4..8].try_into().unwrap())),
-                thread_id: u32::from_le_bytes(bytes[8..12].try_into().unwrap()),
-                payload1_lower: u32::from_le_bytes(bytes[12..16].try_into().unwrap()),
-                payload2_lower: u32::from_le_bytes(bytes[16..20].try_into().unwrap()),
-                payloads_upper: u32::from_le_bytes(bytes[20..24].try_into().unwrap()),
+                event_kind: StringId::new(u64::from_le_bytes(bytes[0..8].try_into().unwrap())),
+                event_id: EventId::from_u64(u64::from_le_bytes(bytes[8..16].try_into().unwrap())),
+                thread_id: u32::from_le_bytes(bytes[16..20].try_into().unwrap()),
+                payload1_lower: u32::from_le_bytes(bytes[20..24].try_into().unwrap()),
+                payload2_lower: u32::from_le_bytes(bytes[24..28].try_into().unwrap()),
+                payloads_upper: u32::from_le_bytes(bytes[28..32].try_into().unwrap()),
             }
         }
     }


### PR DESCRIPTION
This PR fixes the big endian regression tests. Apparently, the have not actually run `cargo check` with a big endian target for a while. The PR also switches the GH action jobs to use a matrix and replaces the unmaintained action-rs with something more current. It also fixes the big-endian-only compilation error that the now fixed tests are running into.

This should unblock https://github.com/rust-lang/rust/pull/119111, once we've done a 11.0.1 release.

r? @wesleywiser 