### PR TITLE
chore: prepare 10.1.3 release for decodeme/mesureme

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,4 +14,7 @@ jobs:
       - name: Publish
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: cargo publish -p measureme
+        run: |
+          # Note: Order is important. Leaf packages need to be published first
+          cargo publish -p measureme
+          cargo publish -p decodeme

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [10.1.3] - 2024-05-30
+
+### Changed
+
+- `decodeme`: Include software license information in Cargo.toml and `.crate` tarball ([GH-231])
+- `measureme`: Include software license information in Cargo.toml and `.crate` tarball ([GH-231])
+
 ## [10.1.2] - 2023-12-14
 
 ### Changed
@@ -161,6 +168,7 @@
 
 ## [0.2.0] - 2019-04-10
 
+[10.1.3]: https://github.com/rust-lang/measureme/releases/tag/10.1.3
 [10.1.2]: https://github.com/rust-lang/measureme/releases/tag/10.1.2
 [10.1.1]: https://github.com/rust-lang/measureme/releases/tag/10.1.1
 [10.1.0]: https://github.com/rust-lang/measureme/releases/tag/10.1.0
@@ -232,3 +240,4 @@
 [GH-208]: https://github.com/rust-lang/measureme/pull/208
 [GH-209]: https://github.com/rust-lang/measureme/pull/209
 [GH-211]: https://github.com/rust-lang/measureme/pull/211
+[GH-231]: https://github.com/rust-lang/measureme/pull/231

--- a/analyzeme/Cargo.toml
+++ b/analyzeme/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "analyzeme"
-version = "10.1.2"
+version = "10.1.3"
 authors = ["Wesley Wiser <wwiser@gmail.com>", "Michael Woerister <michaelwoerister@posteo>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/crox/Cargo.toml
+++ b/crox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crox"
-version = "10.1.2"
+version = "10.1.3"
 authors = ["Wesley Wiser <wwiser@gmail.com>"]
 edition = "2018"
 

--- a/decodeme/Cargo.toml
+++ b/decodeme/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "decodeme"
-version = "10.1.2"
+version = "10.1.3"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/decodeme/Cargo.toml
+++ b/decodeme/Cargo.toml
@@ -1,12 +1,16 @@
 [package]
 name = "decodeme"
+description = "Decoding definitions of the profiling event data from `measureme`"
 version = "10.1.3"
+authors = ["Wesley Wiser <wwiser@gmail.com>", "Michael Woerister <michaelwoerister@posteo>"]
 edition = "2018"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/rust-lang/measureme"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-measureme = { path = "../measureme" }
+measureme = { version = "10.1.3", path = "../measureme" }
 memchr = "2"
 rustc-hash = "1.0.1"
 serde = { version = "1.0", features = ["derive"] }

--- a/decodeme/LICENSE-APACHE
+++ b/decodeme/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/decodeme/LICENSE-MIT
+++ b/decodeme/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/flamegraph/Cargo.toml
+++ b/flamegraph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flamegraph"
-version = "10.1.2"
+version = "10.1.3"
 authors = ["Wesley Wiser <wwiser@gmail.com>", "Michael Woerister <michaelwoerister@posteo>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/measureme/Cargo.toml
+++ b/measureme/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "measureme"
-version = "10.1.2"
+version = "10.1.3"
 authors = ["Wesley Wiser <wwiser@gmail.com>", "Michael Woerister <michaelwoerister@posteo>"]
 edition = "2018"
 description = "Support crate for rustc's self-profiling feature"

--- a/measureme/LICENSE-APACHE
+++ b/measureme/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/measureme/LICENSE-MIT
+++ b/measureme/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/mmedit/Cargo.toml
+++ b/mmedit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mmedit"
-version = "10.1.2"
+version = "10.1.3"
 edition = "2018"
 
 [dependencies]

--- a/mmview/Cargo.toml
+++ b/mmview/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mmview"
-version = "10.1.2"
+version = "10.1.3"
 authors = ["Wesley Wiser <wwiser@gmail.com>", "Michael Woerister <michaelwoerister@posteo>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/stack_collapse/Cargo.toml
+++ b/stack_collapse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stack_collapse"
-version = "10.1.2"
+version = "10.1.3"
 authors = ["Wesley Wiser <wwiser@gmail.com>", "Michael Woerister <michaelwoerister@posteo>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/summarize/Cargo.toml
+++ b/summarize/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "summarize"
-version = "10.1.2"
+version = "10.1.3"
 authors = ["Wesley Wiser <wwiser@gmail.com>", "Michael Woerister <michaelwoerister@posteo>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/version_checker/Cargo.toml
+++ b/version_checker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "version_checker"
-version = "10.1.2"
+version = "10.1.3"
 authors = ["Michael Woerister <michaelwoerister@posteo>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
This is a part of <https://github.com/rust-lang/measureme/issues/229>.

There should be no code change between 10.1.3,
The only change is including open source licenses in Cargo.toml
and the distributable tarball (`.crate` file generated by `cargo package/publish`).

(I'll update changelog after this PR is submitted)