### PR TITLE
Cofigurate out `ohos` target's dependecies  to avoid compilation crashes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ measureme_10 = { version = "10.1.3", package = "measureme" }
 memchr = "2"
 memmap2 = "0.2.1"
 parking_lot = "0.12.0"
-perf-event-open-sys = "3.0.0"
+perf-event-open-sys2 = "5.0.6"
 prettytable-rs = "0.10"
 rustc-hash = "1.0.1"
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ measureme_10 = { version = "10.1.3", package = "measureme" }
 memchr = "2"
 memmap2 = "0.2.1"
 parking_lot = "0.12.0"
-perf-event-open-sys2 = "5.0.6"
+perf-event-open-sys = "3.0.0"
 prettytable-rs = "0.10"
 rustc-hash = "1.0.1"
 serde = { version = "1.0", features = ["derive"] }

--- a/measureme/Cargo.toml
+++ b/measureme/Cargo.toml
@@ -18,4 +18,4 @@ nightly = []
 
 [target.'cfg(all(target_arch = "x86_64", target_os = "linux"))'.dependencies]
 memmap2.workspace = true
-perf-event-open-sys.workspace = true
+perf-event-open-sys2.workspace = true

--- a/measureme/Cargo.toml
+++ b/measureme/Cargo.toml
@@ -16,6 +16,6 @@ smallvec.workspace = true
 [features]
 nightly = []
 
-[target.'cfg(all(target_arch = "x86_64", target_os = "linux"))'.dependencies]
+[target.'cfg(all(target_arch = "x86_64", target_os = "linux", not(target_env = "ohos")))'.dependencies]
 memmap2.workspace = true
-perf-event-open-sys2.workspace = true
+perf-event-open-sys.workspace = true

--- a/measureme/src/counters.rs
+++ b/measureme/src/counters.rs
@@ -349,12 +349,10 @@ mod hw {
             type_: perf_type_id,
             hw_id: u32,
         ) -> Result<Self, Box<dyn Error + Send + Sync>> {
-            let mut attrs = perf_event_attr {
-                size: mem::size_of::<perf_event_attr>().try_into().unwrap(),
-                type_,
-                config: hw_id.into(),
-                ..perf_event_attr::default()
-            };
+            let mut attrs = perf_event_attr::default();
+            attrs.size = mem::size_of::<perf_event_attr>().try_into().unwrap();
+            attrs.type_ = type_;
+            attrs.config = hw_id.into();
 
             // Only record same-thread, any CPUs, and only userspace (no kernel/hypervisor).
             // NOTE(eddyb) `pid = 0`, despite talking about "process id", means


### PR DESCRIPTION
I was trying to build ohos rustc targets. but blocked. It seems that` perf-event-open-sys` support is not good(https://github.com/rust-lang/measureme/issues/237#issuecomment-2484574815).
The new `perf-event-open-sys2` supports this which is an actively maintained fork.

cc https://github.com/rust-lang/measureme/issues/237