### PR TITLE
don't panic on missing page tags

### DIFF
--- a/decodeme/src/lib.rs
+++ b/decodeme/src/lib.rs
@@ -115,13 +115,13 @@ impl EventDecoder {
 
         let string_data = split_data
             .remove(&PageTag::StringData)
-            .expect("Invalid file: No string data found");
+            .ok_or("Invalid file: No string data found")?;
         let index_data = split_data
             .remove(&PageTag::StringIndex)
-            .expect("Invalid file: No string index data found");
+            .ok_or("Invalid file: No string index data found")?;
         let event_data = split_data
             .remove(&PageTag::Events)
-            .expect("Invalid file: No event data found");
+            .ok_or("Invalid file: No event data found")?;
 
         Self::from_separate_buffers(string_data, index_data, event_data, diagnostic_file_path)
     }


### PR DESCRIPTION
Earlier today we had an interesting [perf run](https://github.com/rust-lang/rust/pull/133502#issuecomment-2505625977): a try build seemingly created an invalid .mm_profdata file. This caused a panic in the event decoder checks (that, in turn, made the perf collector panic and infinite loop on the same benchmark 😅), although it supports errors in the file header and magic values. 

This PR expands the error checking and turns these panics into errors so that they can be handled upstream, even though the file the decoder was asked to read is completely invalid. AFAICT it was only the header that was present -- though I can find out more about it if you want?.