### PR TITLE
Bump measureme version to 12.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [12.0.1] - 2025-01-07
+
+### Changed
+
+- `measureme`: Configure out ohos target's dependecies to avoid compilation crashes ([GH-238])
+- `analyzeme`: Do not panic on missing page tags ([GH-239])
+
 ## [12.0.0] - 2024-05-31
 
 ### Added
@@ -199,6 +206,7 @@
 
 ## [0.2.0] - 2019-04-10
 
+[12.0.1]: https://github.com/rust-lang/measureme/releases/tag/12.0.1
 [12.0.0]: https://github.com/rust-lang/measureme/releases/tag/12.0.0
 [11.0.1]: https://github.com/rust-lang/measureme/releases/tag/11.0.1
 [11.0.0]: https://github.com/rust-lang/measureme/releases/tag/11.0.0
@@ -283,3 +291,5 @@
 [GH-228]: https://github.com/rust-lang/measureme/pull/228
 [GH-232]: https://github.com/rust-lang/measureme/pull/232
 [GH-234]: https://github.com/rust-lang/measureme/pull/234
+[GH-238]: https://github.com/rust-lang/measureme/pull/238
+[GH-239]: https://github.com/rust-lang/measureme/pull/239

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,21 +13,21 @@ members = [
 ]
 
 [workspace.package]
-version = "12.0.0"
+version = "12.0.1"
 authors = ["Wesley Wiser <wwiser@gmail.com>", "Michael Woerister <michaelwoerister@posteo>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/measureme"
 
 [workspace.dependencies]
-analyzeme = { version = "12.0.0", path = "analyzeme" }
+analyzeme = { version = "12.0.1", path = "analyzeme" }
 clap = { version = "4.5.0", features = ["derive"] }
-decodeme = { version = "12.0.0", path = "decodeme" }
+decodeme = { version = "12.0.1", path = "decodeme" }
 decodeme_10 = { version = "10.1.3", package = "decodeme" }
 flate2 = "1.0"
 inferno = { version = "0.11", default-features = false }
 log = "0.4"
-measureme = { version = "12.0.0", path = "measureme" }
+measureme = { version = "12.0.1", path = "measureme" }
 measureme_10 = { version = "10.1.3", package = "measureme" }
 memchr = "2"
 memmap2 = "0.2.1"


### PR DESCRIPTION
I've been trying to promote openharmony targets to tier2 with host tools.
and there was a modfify made on the measureme tool. https://github.com/rust-lang/measureme/pull/238 (merged)

I'd like to apply this modification through a new version. 

it's convenient for you to review it?. Really appreciate it.  @michaelwoerister @wesleywiser @weihanglo 