### PR TITLE
make default summarize table output a bit more compact

### DIFF
--- a/summarize/src/main.rs
+++ b/summarize/src/main.rs
@@ -192,6 +192,7 @@ fn summarize(opt: SummarizeOpt) -> Result<(), Box<dyn Error + Send + Sync>> {
         .sort_by(|l, r| r.self_time.cmp(&l.self_time));
 
     let mut table = Table::new();
+    table.set_format(*prettytable::format::consts::FORMAT_NO_LINESEP_WITH_TITLE);
 
     let mut has_cache_hits = false;
     let mut has_blocked_time = false;
@@ -244,11 +245,23 @@ fn summarize(opt: SummarizeOpt) -> Result<(), Box<dyn Error + Send + Sync>> {
             .collect()
     }
 
-    table.add_row(Row::new(filter_cells(columns)));
+    table.set_titles(Row::new(filter_cells(columns)));
 
     let total_time = results.total_time.as_nanos() as f64;
     let mut percent_total_time: f64 = 0.0;
 
+    let mut label_max_width = (results.query_data.iter())
+        .map(|q| q.label.len())
+        .max()
+        .unwrap_or(0);
+    fn pad(s: &str, max: usize) -> String {
+        if s.len() >= max {
+            return s.to_string();
+        }
+
+        let pad = max.saturating_sub(s.len());
+        format!("{s}{:.<pad$}", " ")
+    }
     for query_data in results.query_data {
         let curr_percent = (query_data.self_time.as_nanos() as f64) / total_time * 100.0;
         if curr_percent < percent_above {
@@ -260,7 +273,7 @@ fn summarize(opt: SummarizeOpt) -> Result<(), Box<dyn Error + Send + Sync>> {
         // Don't show the cache hits, blocked time or incremental load time columns unless there is
         // data to show.
         table.add_row(Row::new(filter_cells(&[
-            (&query_data.label, true),
+            (&pad(&query_data.label, label_max_width), true),
             (&format!("{:.2?}", query_data.self_time), true),
             (&format!("{:.3}", curr_percent), true),
             (&format!("{:.2?}", query_data.time), true),
@@ -296,8 +309,9 @@ fn summarize(opt: SummarizeOpt) -> Result<(), Box<dyn Error + Send + Sync>> {
     }
 
     let mut table = Table::new();
+    table.set_format(*prettytable::format::consts::FORMAT_NO_LINESEP_WITH_TITLE);
 
-    table.add_row(row!("Item", "Artifact Size",));
+    table.set_titles(row!("Item", "Artifact Size"));
 
     for artifact_size in results.artifact_sizes {
         table.add_row(row![


### PR DESCRIPTION
I found the default formatting for `summarize summarize <file>` to be visually noisy and difficult to read because of the separators between each line:
```none
$ summarize summarize my-data.mm_profdata
+-----------------------------------------------------------------+-----------+-----------------+----------+------------+---------------------------------+
| Item                                                            | Self time | % of total time | Time     | Item count | Incremental result hashing time |
+-----------------------------------------------------------------+-----------+-----------------+----------+------------+---------------------------------+
| LLVM_passes                                                     | 714.79ms  | 13.408          | 714.79ms | 1          | 0.00ns                          |
+-----------------------------------------------------------------+-----------+-----------------+----------+------------+---------------------------------+
| run_linker                                                      | 706.56ms  | 13.253          | 706.56ms | 1          | 0.00ns                          |
+-----------------------------------------------------------------+-----------+-----------------+----------+------------+---------------------------------+
| LLVM_module_codegen_emit_obj                                    | 690.58ms  | 12.954          | 690.58ms | 173        | 0.00ns                          |
+-----------------------------------------------------------------+-----------+-----------------+----------+------------+---------------------------------+
| codegen_module                                                  | 401.81ms  | 7.537           | 748.49ms | 172        | 0.00ns                          |

... and so on for like 2 pages of scrolling
```

This change removes the separating lines `+-----+---+` between rows. This introduces a new problem where it is hard to read a line as there's often a lot of whitespace between the end of the item label and the beginning of the next column. I added some `...` to pad out the line to make it easier to scan.
```none
$ target/debug/summarize summarize my-data.mm_profdata
+-----------------------------------------------------------------+-----------+-----------------+----------+------------+---------------------------------+
| Item                                                            | Self time | % of total time | Time     | Item count | Incremental result hashing time |
+-----------------------------------------------------------------+-----------+-----------------+----------+------------+---------------------------------+
| LLVM_passes ................................................... | 714.79ms  | 13.408          | 714.79ms | 1          | 0.00ns                          |
| run_linker .................................................... | 706.56ms  | 13.253          | 706.56ms | 1          | 0.00ns                          |
| LLVM_module_codegen_emit_obj .................................. | 690.58ms  | 12.954          | 690.58ms | 173        | 0.00ns                          |
| codegen_module ................................................ | 401.81ms  | 7.537           | 748.49ms | 172        | 0.00ns                          |
| incr_comp_encode_dep_graph .................................... | 302.17ms  | 5.668           | 302.17ms | 223438     | 0.00ns                          |
| implementations_of_trait ...................................... | 280.60ms  | 5.263           | 395.25ms | 44604      | 112.82ms                        |
```

I think the final result is able to present more data in a single screen, while also not sacrificing ease of scanning horizontally.