### PR TITLE
summarize: Don't panic on broken pipe

### DIFF
--- a/summarize/src/main.rs
+++ b/summarize/src/main.rs
@@ -5,7 +5,7 @@ use analyzeme::AnalysisResults;
 use analyzeme::ProfilingData;
 use std::error::Error;
 use std::fs::File;
-use std::io::{BufReader, BufWriter};
+use std::io::{BufReader, BufWriter, Write};
 use std::{path::PathBuf, time::Duration};
 
 use clap::Parser;
@@ -142,7 +142,11 @@ fn diff(opt: DiffOpt) -> Result<(), Box<dyn Error + Send + Sync>> {
 
     table.printstd();
 
-    println!("Total cpu time: {:?}", results.total_time);
+    _ = writeln!(
+        std::io::stdout(),
+        "Total cpu time: {:?}",
+        results.total_time
+    );
 
     let mut table = Table::new();
 
@@ -286,10 +290,15 @@ fn summarize(opt: SummarizeOpt) -> Result<(), Box<dyn Error + Send + Sync>> {
 
     table.printstd();
 
-    println!("Total cpu time: {:?}", results.total_time);
+    _ = writeln!(
+        std::io::stdout(),
+        "Total cpu time: {:?}",
+        results.total_time
+    );
 
     if percent_above != 0.0 {
-        println!(
+        _ = writeln!(
+            std::io::stdout(),
             "Filtered results account for {:.3}% of total time.",
             percent_total_time
         );


### PR DESCRIPTION
I hit #31 while piping summarize to head. The original issue was in part due to `prettytable` panicking. That's since been upgraded to a version with the fix, but some of the `println!`s that happen after `table.printstd()` will also panic from the broken pipe:

```sh-session
$ summarize summarize ... | head
...
thread 'main' panicked at library/std/src/io/stdio.rs:1165:9:
failed printing to stdout: Broken pipe (os error 32)
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

To fix this, change the `println!`s to `writeln!`s, and ignore any errors.

Fixes #31.