### PR TITLE
Add support for reading aggregated query cache hit counts

### DIFF
--- a/measureme/src/rustc.rs
+++ b/measureme/src/rustc.rs
@@ -12,4 +12,7 @@ pub const QUERY_BLOCKED_EVENT_KIND: &str = "QueryBlocked";
 
 pub const QUERY_CACHE_HIT_EVENT_KIND: &str = "QueryCacheHit";
 
+/// Aggregated count of query cache hits, stored as an integer event.
+pub const QUERY_CACHE_HIT_COUNT_EVENT_KIND: &str = "QueryCacheHitCount";
+
 pub const ARTIFACT_SIZE_EVENT_KIND: &str = "ArtifactSize";


### PR DESCRIPTION
This adds support to the analysis module for aggregated query cache hit counts, which were added to rustc in https://github.com/rust-lang/rust/pull/142978. I tried to keep compatibility with the original (very expensive) per-query-invocation cache hit counters.