### PR TITLE
Use merge queues for the repository

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,14 +1,8 @@
 name: Rust
 
 on:
-  push:
-    branches:
-      - master
-      - stable
+  merge_group:
   pull_request:
-    branches:
-      - master
-      - stable
 
 env:
   CARGO_TERM_COLOR: always
@@ -46,7 +40,7 @@ jobs:
     # GitHub branch protection is exceedingly silly and treats "jobs skipped because a dependency
     # failed" as success. So we have to do some contortions to ensure the job fails if any of its
     # dependencies fails.
-    if: always() # make sure this is never "skipped"
+    if: ${{ !cancelled() }} # make sure this is never "skipped"
     steps:
       # Manually check the status of all dependencies. `if: failure()` does not work.
       - name: check if any dependency failed


### PR DESCRIPTION
Before this PR is merged, merge queue should be configured for the "success" job (for the `master` branch), and the option "require branches to be up-to-date" should be unchecked.