### PR TITLE
Configure crates.io publish using OIDC

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,12 +11,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust (rustup)
-        run: rustup update stable && rustup default stable
+        run: rustup update nightly && rustup default nightly
       - name: Publish
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: |
-          # Note: Order is important. Leaf packages need to be published first.
-          cargo publish -p measureme
-          cargo publish -p decodeme
-          cargo publish -p analyzeme
+        run:
+          cargo +nightly publish -Zpackage-workspace --workspace

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,6 +2,7 @@ name: Publish
 on:
   release:
     types: [created]
+  workflow_dispatch:
 
 jobs:
   publish:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,8 +12,11 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install Rust (rustup)
         run: rustup update nightly && rustup default nightly
-      - name: Publish
+      - name: Authenticate with crates.io
+        id: auth
+        uses: rust-lang/crates-io-auth-action@v1
+      - name: Publish to crates.io
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
         run:
           cargo +nightly publish -Zpackage-workspace --workspace

--- a/crox/Cargo.toml
+++ b/crox/Cargo.toml
@@ -6,6 +6,7 @@ authors.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+publish = false
 
 [dependencies]
 analyzeme.workspace = true

--- a/flamegraph/Cargo.toml
+++ b/flamegraph/Cargo.toml
@@ -6,6 +6,7 @@ authors.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+publish = false
 
 [dependencies]
 analyzeme.workspace = true

--- a/mmedit/Cargo.toml
+++ b/mmedit/Cargo.toml
@@ -6,6 +6,7 @@ authors.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+publish = false
 
 [dependencies]
 clap.workspace = true

--- a/mmview/Cargo.toml
+++ b/mmview/Cargo.toml
@@ -6,6 +6,7 @@ authors.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+publish = false
 
 [dependencies]
 analyzeme.workspace = true

--- a/stack_collapse/Cargo.toml
+++ b/stack_collapse/Cargo.toml
@@ -6,6 +6,7 @@ authors.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+publish = false
 
 [dependencies]
 analyzeme.workspace = true

--- a/summarize/Cargo.toml
+++ b/summarize/Cargo.toml
@@ -6,6 +6,7 @@ authors.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+publish = false
 
 [dependencies]
 analyzeme.workspace = true


### PR DESCRIPTION
This dogfoods two things =D The new trusted publishing feature of crates.io, and the soon-to-be-stabilized workspace publish feature of Cargo.

CC @marcoieni